### PR TITLE
Add Zakat calculation and settings

### DIFF
--- a/bwk-accounting-lite/admin/views-invoice-edit.php
+++ b/bwk-accounting-lite/admin/views-invoice-edit.php
@@ -53,6 +53,8 @@ $invoice_id = $invoice ? intval( $invoice->id ) : 0;
             <td><input name="tax_total" id="tax_total" type="number" step="0.01" value="<?php echo esc_attr( $invoice ? $invoice->tax_total : 0 ); ?>" /></td></tr>
             <tr><th><label for="shipping_total"><?php _e( 'Shipping', 'bwk-accounting-lite' ); ?></label></th>
             <td><input name="shipping_total" id="shipping_total" type="number" step="0.01" value="<?php echo esc_attr( $invoice ? $invoice->shipping_total : 0 ); ?>" /></td></tr>
+            <tr><th><label for="zakat_total"><?php _e( 'Zakat', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="zakat_total" id="zakat_total" type="number" step="0.01" value="<?php echo esc_attr( $invoice ? $invoice->zakat_total : 0 ); ?>" readonly /></td></tr>
             <tr><th><label for="grand_total"><?php _e( 'Grand Total', 'bwk-accounting-lite' ); ?></label></th>
             <td><input name="grand_total" id="grand_total" type="number" step="0.01" value="<?php echo esc_attr( $invoice ? $invoice->grand_total : 0 ); ?>" /></td></tr>
             <tr><th><label for="currency"><?php _e( 'Currency', 'bwk-accounting-lite' ); ?></label></th>

--- a/bwk-accounting-lite/admin/views-settings.php
+++ b/bwk-accounting-lite/admin/views-settings.php
@@ -28,6 +28,10 @@ $active = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'general';
                 <td><input name="bwk_accounting_company_email" id="bwk_accounting_company_email" type="email" value="<?php echo esc_attr( bwk_get_option( 'company_email' ) ); ?>" class="regular-text" /></td></tr>
                 <tr><th><label for="bwk_accounting_default_currency"><?php _e( 'Default Currency', 'bwk-accounting-lite' ); ?></label></th>
                 <td><input name="bwk_accounting_default_currency" id="bwk_accounting_default_currency" type="text" value="<?php echo esc_attr( bwk_get_option( 'default_currency', 'USD' ) ); ?>" class="regular-text" /></td></tr>
+                <tr><th scope="row"><?php _e( 'Enable Zakat', 'bwk-accounting-lite' ); ?></th>
+                <td><input type="checkbox" name="bwk_accounting_enable_zakat" value="1" <?php checked( bwk_get_option( 'enable_zakat', 0 ), 1 ); ?> /></td></tr>
+                <tr><th><label for="bwk_accounting_zakat_rate"><?php _e( 'Zakat Rate (%)', 'bwk-accounting-lite' ); ?></label></th>
+                <td><input name="bwk_accounting_zakat_rate" id="bwk_accounting_zakat_rate" type="number" step="0.01" value="<?php echo esc_attr( bwk_get_option( 'zakat_rate', 2.5 ) ); ?>" /></td></tr>
             </table>
             <?php
         } elseif ( 'numbering' === $active ) {

--- a/bwk-accounting-lite/bwk-accounting-lite.php
+++ b/bwk-accounting-lite/bwk-accounting-lite.php
@@ -34,6 +34,7 @@ register_deactivation_hook( __FILE__, array( 'BWK_Deactivator', 'deactivate' ) )
 register_uninstall_hook( __FILE__, array( 'BWK_Uninstaller', 'uninstall' ) );
 
 function bwk_accounting_lite_init() {
+    BWK_Activator::upgrade();
     BWK_Settings::init();
     BWK_Admin_Menu::init();
     BWK_Invoices::init();

--- a/bwk-accounting-lite/includes/class-activator.php
+++ b/bwk-accounting-lite/includes/class-activator.php
@@ -26,6 +26,7 @@ class BWK_Activator {
             discount_total decimal(18,2) NOT NULL DEFAULT 0,
             tax_total decimal(18,2) NOT NULL DEFAULT 0,
             shipping_total decimal(18,2) NOT NULL DEFAULT 0,
+            zakat_total decimal(18,2) NOT NULL DEFAULT 0,
             grand_total decimal(18,2) NOT NULL DEFAULT 0,
             notes text NULL,
             wc_order_id bigint(20) unsigned NULL,
@@ -68,5 +69,14 @@ class BWK_Activator {
         dbDelta( $sql_invoices );
         dbDelta( $sql_items );
         dbDelta( $sql_ledger );
+    }
+
+    public static function upgrade() {
+        global $wpdb;
+        $table = bwk_table_invoices();
+        $col   = $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM $table LIKE %s", 'zakat_total' ) );
+        if ( ! $col ) {
+            self::activate();
+        }
     }
 }

--- a/bwk-accounting-lite/includes/class-ledger.php
+++ b/bwk-accounting-lite/includes/class-ledger.php
@@ -27,6 +27,16 @@ class BWK_Ledger {
         $wpdb->insert( bwk_table_ledger(), $data );
     }
 
+    public static function insert_zakat( $invoice_id, $amount, $currency ) {
+        self::insert_entry( array(
+            'source'    => 'invoice',
+            'source_id' => $invoice_id,
+            'txn_type'  => 'zakat',
+            'amount'    => $amount,
+            'currency'  => $currency,
+        ) );
+    }
+
     public static function render_list_page() {
         if ( ! bwk_current_user_can() ) {
             return;

--- a/bwk-accounting-lite/includes/class-settings.php
+++ b/bwk-accounting-lite/includes/class-settings.php
@@ -16,6 +16,8 @@ class BWK_Settings {
         register_setting( 'bwk_settings_general', 'bwk_accounting_company_name' );
         register_setting( 'bwk_settings_general', 'bwk_accounting_company_email' );
         register_setting( 'bwk_settings_general', 'bwk_accounting_default_currency' );
+        register_setting( 'bwk_settings_general', 'bwk_accounting_enable_zakat' );
+        register_setting( 'bwk_settings_general', 'bwk_accounting_zakat_rate' );
         register_setting( 'bwk_settings_numbering', 'bwk_accounting_number_prefix' );
         register_setting( 'bwk_settings_numbering', 'bwk_accounting_number_padding' );
         register_setting( 'bwk_settings_advanced', 'bwk_accounting_remove_data' );

--- a/bwk-accounting-lite/public/templates/invoice-a4.php
+++ b/bwk-accounting-lite/public/templates/invoice-a4.php
@@ -35,6 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
         <tr><th><?php _e( 'Discount', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $invoice->discount_total ); ?></td></tr>
         <tr><th><?php _e( 'Tax', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $invoice->tax_total ); ?></td></tr>
         <tr><th><?php _e( 'Shipping', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $invoice->shipping_total ); ?></td></tr>
+        <tr><th><?php _e( 'Zakat', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $invoice->zakat_total ); ?></td></tr>
         <tr><th><?php _e( 'Grand Total', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $invoice->grand_total ); ?></td></tr>
     </table>
     <footer>


### PR DESCRIPTION
## Summary
- add `zakat_total` column and upgrade routine for invoices table
- allow admins to enable Zakat and configure its rate
- compute Zakat on invoice save, record ledger entry, and display it in admin and print views

## Testing
- `php -l includes/class-activator.php`
- `php -l includes/class-settings.php`
- `php -l includes/class-invoices-tables.php`
- `php -l includes/class-ledger.php`
- `php -l admin/views-settings.php`
- `php -l admin/views-invoice-edit.php`
- `php -l public/templates/invoice-a4.php`
- `php -l bwk-accounting-lite.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf88b3a68083309e0321c0665de336