### PR TITLE
Add quotes tables, CRUD class, admin UI, and printable template

### DIFF
--- a/bwk-accounting-lite/admin/views-quote-edit.php
+++ b/bwk-accounting-lite/admin/views-quote-edit.php
@@ -1,0 +1,65 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+$quote_id = $quote ? intval( $quote->id ) : 0;
+?>
+<div class="wrap">
+    <h1><?php echo $quote_id ? esc_html__( 'Edit Quote', 'bwk-accounting-lite' ) : esc_html__( 'Add Quote', 'bwk-accounting-lite' ); ?></h1>
+    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+        <?php wp_nonce_field( 'bwk_save_quote' ); ?>
+        <input type="hidden" name="action" value="bwk_save_quote" />
+        <input type="hidden" name="quote_id" value="<?php echo esc_attr( $quote_id ); ?>" />
+        <table class="form-table">
+            <tr><th><label for="number"><?php _e( 'Number', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="number" id="number" type="text" value="<?php echo esc_attr( $quote ? $quote->number : '' ); ?>" class="regular-text" /></td></tr>
+            <tr><th><label for="status"><?php _e( 'Status', 'bwk-accounting-lite' ); ?></label></th>
+            <td><select name="status" id="status">
+                <?php foreach ( array( 'draft','sent','accepted','declined' ) as $st ) : ?>
+                    <option value="<?php echo esc_attr( $st ); ?>" <?php selected( $quote && $quote->status === $st ); ?>><?php echo esc_html( ucfirst( $st ) ); ?></option>
+                <?php endforeach; ?>
+            </select></td></tr>
+            <tr><th><label for="customer_name"><?php _e( 'Customer Name', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="customer_name" id="customer_name" type="text" value="<?php echo esc_attr( $quote ? $quote->customer_name : '' ); ?>" class="regular-text" /></td></tr>
+            <tr><th><label for="customer_email"><?php _e( 'Customer Email', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="customer_email" id="customer_email" type="email" value="<?php echo esc_attr( $quote ? $quote->customer_email : '' ); ?>" class="regular-text" /></td></tr>
+            <tr><th><label for="billing_address"><?php _e( 'Billing Address', 'bwk-accounting-lite' ); ?></label></th>
+            <td><textarea name="billing_address" id="billing_address" rows="4" class="large-text"><?php echo esc_textarea( $quote ? $quote->billing_address : '' ); ?></textarea></td></tr>
+        </table>
+        <h2><?php _e( 'Items', 'bwk-accounting-lite' ); ?></h2>
+        <table class="widefat" id="bwk-items-table">
+            <thead><tr><th><?php _e( 'Item', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Qty', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Unit Price', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Line Total', 'bwk-accounting-lite' ); ?></th><th>&nbsp;</th></tr></thead>
+            <tbody>
+                <?php
+                if ( $items ) {
+                    foreach ( $items as $it ) {
+                        echo '<tr><td><input type="text" name="item_name[]" value="' . esc_attr( $it->item_name ) . '" /></td>';
+                        echo '<td><input type="number" step="0.01" name="qty[]" value="' . esc_attr( $it->qty ) . '" class="bwk-qty" /></td>';
+                        echo '<td><input type="number" step="0.01" name="unit_price[]" value="' . esc_attr( $it->unit_price ) . '" class="bwk-price" /></td>';
+                        echo '<td class="bwk-line-total">' . esc_html( $it->line_total ) . '</td><td><button type="button" class="button bwk-remove">&times;</button></td></tr>';
+                    }
+                }
+                ?>
+            </tbody>
+        </table>
+        <p><button type="button" class="button" id="bwk-add-row"><?php _e( 'Add Item', 'bwk-accounting-lite' ); ?></button></p>
+        <h2><?php _e( 'Totals', 'bwk-accounting-lite' ); ?></h2>
+        <table class="form-table">
+            <tr><th><label for="subtotal"><?php _e( 'Subtotal', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="subtotal" id="subtotal" type="number" step="0.01" value="<?php echo esc_attr( $quote ? $quote->subtotal : 0 ); ?>" /></td></tr>
+            <tr><th><label for="discount_total"><?php _e( 'Discount', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="discount_total" id="discount_total" type="number" step="0.01" value="<?php echo esc_attr( $quote ? $quote->discount_total : 0 ); ?>" /></td></tr>
+            <tr><th><label for="tax_total"><?php _e( 'Tax', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="tax_total" id="tax_total" type="number" step="0.01" value="<?php echo esc_attr( $quote ? $quote->tax_total : 0 ); ?>" /></td></tr>
+            <tr><th><label for="shipping_total"><?php _e( 'Shipping', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="shipping_total" id="shipping_total" type="number" step="0.01" value="<?php echo esc_attr( $quote ? $quote->shipping_total : 0 ); ?>" /></td></tr>
+            <tr><th><label for="grand_total"><?php _e( 'Grand Total', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="grand_total" id="grand_total" type="number" step="0.01" value="<?php echo esc_attr( $quote ? $quote->grand_total : 0 ); ?>" /></td></tr>
+            <tr><th><label for="currency"><?php _e( 'Currency', 'bwk-accounting-lite' ); ?></label></th>
+            <td><input name="currency" id="currency" type="text" value="<?php echo esc_attr( $quote ? $quote->currency : bwk_get_option( 'default_currency', 'USD' ) ); ?>" class="regular-text" /></td></tr>
+            <tr><th><label for="notes"><?php _e( 'Notes', 'bwk-accounting-lite' ); ?></label></th>
+            <td><textarea name="notes" id="notes" rows="4" class="large-text"><?php echo esc_textarea( $quote ? $quote->notes : '' ); ?></textarea></td></tr>
+        </table>
+        <?php submit_button( __( 'Save Quote', 'bwk-accounting-lite' ) ); ?>
+    </form>
+</div>

--- a/bwk-accounting-lite/admin/views-quotes-list.php
+++ b/bwk-accounting-lite/admin/views-quotes-list.php
@@ -1,0 +1,27 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="wrap">
+    <h1><?php _e( 'Quotes', 'bwk-accounting-lite' ); ?> <a href="<?php echo esc_url( admin_url( 'admin.php?page=bwk-quote-add' ) ); ?>" class="page-title-action"><?php _e( 'Add New', 'bwk-accounting-lite' ); ?></a></h1>
+    <table class="widefat fixed">
+        <thead><tr><th><?php _e( 'Number', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Customer', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Status', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Total', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Date', 'bwk-accounting-lite' ); ?></th><th>&nbsp;</th></tr></thead>
+        <tbody>
+            <?php if ( $quotes ) : foreach ( $quotes as $qt ) : ?>
+                <tr>
+                    <td><?php echo esc_html( $qt->number ); ?></td>
+                    <td><?php echo esc_html( $qt->customer_name ); ?></td>
+                    <td><?php echo esc_html( ucfirst( $qt->status ) ); ?></td>
+                    <td><?php echo esc_html( $qt->grand_total ); ?></td>
+                    <td><?php echo esc_html( mysql2date( 'Y-m-d', $qt->created_at ) ); ?></td>
+                    <td><a href="<?php echo esc_url( admin_url( 'admin.php?page=bwk-quote-add&id=' . $qt->id ) ); ?>"><?php _e( 'Edit', 'bwk-accounting-lite' ); ?></a> |
+                        <a href="<?php echo esc_url( admin_url( 'admin-post.php?action=bwk_convert_quote&id=' . $qt->id ) ); ?>"><?php _e( 'Convert', 'bwk-accounting-lite' ); ?></a> |
+                        <a href="<?php echo esc_url( add_query_arg( array( 'bwk_quote' => $qt->id, '_nonce' => wp_create_nonce( 'bwk_print_quote_' . $qt->id ) ), home_url() ) ); ?>" target="_blank"><?php _e( 'Print', 'bwk-accounting-lite' ); ?></a></td>
+                </tr>
+            <?php endforeach; else : ?>
+                <tr><td colspan="6"><?php _e( 'No quotes found.', 'bwk-accounting-lite' ); ?></td></tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>

--- a/bwk-accounting-lite/bwk-accounting-lite.php
+++ b/bwk-accounting-lite/bwk-accounting-lite.php
@@ -38,6 +38,7 @@ function bwk_accounting_lite_init() {
     BWK_Settings::init();
     BWK_Admin_Menu::init();
     BWK_Invoices::init();
+    BWK_Quotes_Table::init();
     BWK_Ledger::init();
     BWK_Sync_WooCommerce::init();
     BWK_Ajax::init();

--- a/bwk-accounting-lite/includes/class-admin-menu.php
+++ b/bwk-accounting-lite/includes/class-admin-menu.php
@@ -19,6 +19,8 @@ class BWK_Admin_Menu {
         add_menu_page( __( 'BWK Accounting', 'bwk-accounting-lite' ), __( 'BWK Accounting', 'bwk-accounting-lite' ), $cap, 'bwk-accounting', array( 'BWK_Invoices', 'render_list_page' ), 'dashicons-media-spreadsheet', 56 );
         add_submenu_page( 'bwk-accounting', __( 'Invoices', 'bwk-accounting-lite' ), __( 'Invoices', 'bwk-accounting-lite' ), $cap, 'bwk-accounting', array( 'BWK_Invoices', 'render_list_page' ) );
         add_submenu_page( 'bwk-accounting', __( 'Add New Invoice', 'bwk-accounting-lite' ), __( 'Add New', 'bwk-accounting-lite' ), $cap, 'bwk-invoice-add', array( 'BWK_Invoices', 'render_edit_page' ) );
+        add_submenu_page( 'bwk-accounting', __( 'Quotes', 'bwk-accounting-lite' ), __( 'Quotes', 'bwk-accounting-lite' ), $cap, 'bwk-quotes', array( 'BWK_Quotes_Table', 'render_list_page' ) );
+        add_submenu_page( 'bwk-accounting', __( 'Add New Quote', 'bwk-accounting-lite' ), __( 'Add Quote', 'bwk-accounting-lite' ), $cap, 'bwk-quote-add', array( 'BWK_Quotes_Table', 'render_edit_page' ) );
         add_submenu_page( 'bwk-accounting', __( 'Ledger', 'bwk-accounting-lite' ), __( 'Ledger', 'bwk-accounting-lite' ), $cap, 'bwk-ledger', array( 'BWK_Ledger', 'render_list_page' ) );
         add_submenu_page( 'bwk-accounting', __( 'Settings', 'bwk-accounting-lite' ), __( 'Settings', 'bwk-accounting-lite' ), $cap, 'bwk-settings', array( 'BWK_Settings', 'render_settings_page' ) );
     }

--- a/bwk-accounting-lite/includes/class-quotes-table.php
+++ b/bwk-accounting-lite/includes/class-quotes-table.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Quote table management.
+ *
+ * @author Wan Mohd Aiman Binawebpro.com
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class BWK_Quotes_Table {
+    public static function init() {
+        add_action( 'admin_post_bwk_save_quote', array( __CLASS__, 'save_quote' ) );
+        add_action( 'admin_post_bwk_convert_quote', array( __CLASS__, 'convert_to_invoice' ) );
+        add_action( 'admin_init', array( __CLASS__, 'maybe_render_print_quote' ) );
+        add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
+    }
+
+    public static function register_rest_routes() {
+        register_rest_route( 'bwk-accounting/v1', '/quote/(?P<id>\\d+)', array(
+            'methods'             => 'GET',
+            'callback'            => array( __CLASS__, 'rest_get_quote' ),
+            'permission_callback' => '__return_true',
+        ) );
+    }
+
+    public static function rest_get_quote( $request ) {
+        $quote = self::get_quote( intval( $request['id'] ) );
+        if ( ! $quote ) {
+            return new WP_Error( 'not_found', 'Quote not found', array( 'status' => 404 ) );
+        }
+        return rest_ensure_response( $quote );
+    }
+
+    public static function get_quote( $id ) {
+        global $wpdb;
+        $quote = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_quotes() . ' WHERE id=%d', $id ) );
+        if ( ! $quote ) {
+            return null;
+        }
+        $items = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_quote_items() . ' WHERE quote_id=%d ORDER BY line_no ASC', $id ) );
+        $quote->items = $items;
+        return $quote;
+    }
+
+    public static function render_list_page() {
+        if ( ! bwk_current_user_can() ) {
+            return;
+        }
+        global $wpdb;
+        $quotes = $wpdb->get_results( 'SELECT * FROM ' . bwk_table_quotes() . ' ORDER BY created_at DESC' );
+        include BWK_AL_PATH . 'admin/views-quotes-list.php';
+    }
+
+    public static function render_edit_page() {
+        if ( ! bwk_current_user_can() ) {
+            return;
+        }
+        global $wpdb;
+        $id    = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0;
+        $quote = null;
+        $items = array();
+        if ( $id ) {
+            $quote = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_quotes() . ' WHERE id=%d', $id ) );
+            $items = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_quote_items() . ' WHERE quote_id=%d ORDER BY line_no ASC', $id ) );
+        }
+        include BWK_AL_PATH . 'admin/views-quote-edit.php';
+    }
+
+    public static function save_quote() {
+        if ( ! bwk_current_user_can() ) {
+            wp_die( 'Access denied' );
+        }
+        check_admin_referer( 'bwk_save_quote' );
+        global $wpdb;
+        $table   = bwk_table_quotes();
+        $item_tb = bwk_table_quote_items();
+
+        $id     = isset( $_POST['quote_id'] ) ? intval( $_POST['quote_id'] ) : 0;
+        $number = sanitize_text_field( $_POST['number'] );
+        if ( empty( $number ) ) {
+            $number = bwk_next_quote_number();
+        }
+
+        $data = array(
+            'number'         => $number,
+            'status'         => sanitize_text_field( $_POST['status'] ),
+            'customer_name'  => sanitize_text_field( $_POST['customer_name'] ),
+            'customer_email' => sanitize_email( $_POST['customer_email'] ),
+            'billing_address'=> sanitize_textarea_field( $_POST['billing_address'] ),
+            'currency'       => sanitize_text_field( $_POST['currency'] ),
+            'subtotal'       => floatval( $_POST['subtotal'] ),
+            'discount_total' => floatval( $_POST['discount_total'] ),
+            'tax_total'      => floatval( $_POST['tax_total'] ),
+            'shipping_total' => floatval( $_POST['shipping_total'] ),
+            'grand_total'    => floatval( $_POST['grand_total'] ),
+            'notes'          => sanitize_textarea_field( $_POST['notes'] ),
+            'updated_at'     => current_time( 'mysql' ),
+        );
+        if ( $id ) {
+            $wpdb->update( $table, $data, array( 'id' => $id ) );
+        } else {
+            $data['created_at'] = current_time( 'mysql' );
+            $wpdb->insert( $table, $data );
+            $id = $wpdb->insert_id;
+        }
+
+        $wpdb->delete( $item_tb, array( 'quote_id' => $id ) );
+        if ( isset( $_POST['item_name'] ) && is_array( $_POST['item_name'] ) ) {
+            $line_no = 0;
+            foreach ( $_POST['item_name'] as $idx => $name ) {
+                $name = sanitize_text_field( $name );
+                if ( '' === $name ) {
+                    continue;
+                }
+                $qty   = floatval( $_POST['qty'][ $idx ] );
+                $price = floatval( $_POST['unit_price'][ $idx ] );
+                $total = $qty * $price;
+                $wpdb->insert( $item_tb, array(
+                    'quote_id'   => $id,
+                    'line_no'    => $line_no,
+                    'item_name'  => $name,
+                    'qty'        => $qty,
+                    'unit_price' => $price,
+                    'line_total' => $total,
+                ) );
+                $line_no++;
+            }
+        }
+
+        wp_redirect( admin_url( 'admin.php?page=bwk-quotes' ) );
+        exit;
+    }
+
+    public static function convert_to_invoice() {
+        if ( ! bwk_current_user_can() ) {
+            wp_die( 'Access denied' );
+        }
+        $id    = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0;
+        $quote = self::get_quote( $id );
+        if ( ! $quote ) {
+            wp_die( 'Quote not found' );
+        }
+        global $wpdb;
+        $inv_tb  = bwk_table_invoices();
+        $item_tb = bwk_table_invoice_items();
+        $inv_data = array(
+            'number'         => bwk_next_invoice_number(),
+            'status'         => 'draft',
+            'customer_name'  => $quote->customer_name,
+            'customer_email' => $quote->customer_email,
+            'billing_address'=> $quote->billing_address,
+            'currency'       => $quote->currency,
+            'subtotal'       => $quote->subtotal,
+            'discount_total' => $quote->discount_total,
+            'tax_total'      => $quote->tax_total,
+            'shipping_total' => $quote->shipping_total,
+            'grand_total'    => $quote->grand_total,
+            'notes'          => $quote->notes,
+            'created_at'     => current_time( 'mysql' ),
+            'updated_at'     => current_time( 'mysql' ),
+        );
+        $wpdb->insert( $inv_tb, $inv_data );
+        $invoice_id = $wpdb->insert_id;
+        foreach ( $quote->items as $i => $it ) {
+            $wpdb->insert( $item_tb, array(
+                'invoice_id' => $invoice_id,
+                'line_no'    => $i,
+                'item_name'  => $it->item_name,
+                'qty'        => $it->qty,
+                'unit_price' => $it->unit_price,
+                'line_total' => $it->line_total,
+            ) );
+        }
+        wp_redirect( admin_url( 'admin.php?page=bwk-invoice-add&id=' . $invoice_id ) );
+        exit;
+    }
+
+    public static function maybe_render_print_quote() {
+        if ( isset( $_GET['bwk_quote'] ) ) {
+            $id    = intval( $_GET['bwk_quote'] );
+            $nonce = isset( $_GET['_nonce'] ) ? sanitize_text_field( $_GET['_nonce'] ) : '';
+            if ( ! wp_verify_nonce( $nonce, 'bwk_print_quote_' . $id ) ) {
+                wp_die( 'Invalid nonce' );
+            }
+            $quote = self::get_quote( $id );
+            if ( ! $quote ) {
+                wp_die( 'Quote not found' );
+            }
+            $items = $quote->items;
+            header( 'X-Robots-Tag: noindex, nofollow', true );
+            include BWK_AL_PATH . 'public/templates/quote-a4.php';
+            exit;
+        }
+    }
+}

--- a/bwk-accounting-lite/includes/helpers.php
+++ b/bwk-accounting-lite/includes/helpers.php
@@ -19,6 +19,16 @@ function bwk_table_invoice_items() {
     return $wpdb->prefix . 'bwk_invoice_items';
 }
 
+function bwk_table_quotes() {
+    global $wpdb;
+    return $wpdb->prefix . 'bwk_quotes';
+}
+
+function bwk_table_quote_items() {
+    global $wpdb;
+    return $wpdb->prefix . 'bwk_quote_items';
+}
+
 function bwk_table_ledger() {
     global $wpdb;
     return $wpdb->prefix . 'bwk_ledger';
@@ -38,6 +48,15 @@ function bwk_next_invoice_number() {
     $seq++;
     bwk_update_option( 'invoice_seq', $seq );
     $prefix = bwk_get_option( 'number_prefix', 'INV-' );
+    $pad    = (int) bwk_get_option( 'number_padding', 4 );
+    return $prefix . str_pad( (string) $seq, $pad, '0', STR_PAD_LEFT );
+}
+
+function bwk_next_quote_number() {
+    $seq = (int) bwk_get_option( 'quote_seq', 0 );
+    $seq++;
+    bwk_update_option( 'quote_seq', $seq );
+    $prefix = bwk_get_option( 'quote_prefix', 'QT-' );
     $pad    = (int) bwk_get_option( 'number_padding', 4 );
     return $prefix . str_pad( (string) $seq, $pad, '0', STR_PAD_LEFT );
 }

--- a/bwk-accounting-lite/public/templates/quote-a4.php
+++ b/bwk-accounting-lite/public/templates/quote-a4.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Quote printable template.
+ *
+ * @author Wan Mohd Aiman Binawebpro.com
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?><!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title><?php echo esc_html( $quote->number ); ?></title>
+<link rel="stylesheet" href="<?php echo esc_url( BWK_AL_URL . 'public/css/public.css' ); ?>" />
+</head>
+<body class="bwk-quote">
+<div class="invoice-wrapper">
+    <header>
+        <h1><?php echo esc_html( bwk_get_option( 'company_name', get_bloginfo( 'name' ) ) ); ?></h1>
+        <p><?php echo esc_html( bwk_get_option( 'company_email' ) ); ?></p>
+    </header>
+    <h2><?php _e( 'Quote', 'bwk-accounting-lite' ); ?> <?php echo esc_html( $quote->number ); ?></h2>
+    <p><strong><?php _e( 'Bill To:', 'bwk-accounting-lite' ); ?></strong> <?php echo esc_html( $quote->customer_name ); ?><br/><?php echo nl2br( esc_html( $quote->billing_address ) ); ?></p>
+    <table class="items">
+        <thead><tr><th><?php _e( 'Item', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Qty', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Price', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Total', 'bwk-accounting-lite' ); ?></th></tr></thead>
+        <tbody>
+            <?php foreach ( $items as $it ) : ?>
+            <tr>
+                <td><?php echo esc_html( $it->item_name ); ?></td>
+                <td><?php echo esc_html( $it->qty ); ?></td>
+                <td><?php echo esc_html( $it->unit_price ); ?></td>
+                <td><?php echo esc_html( $it->line_total ); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <table class="totals">
+        <tr><th><?php _e( 'Subtotal', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $quote->subtotal ); ?></td></tr>
+        <tr><th><?php _e( 'Discount', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $quote->discount_total ); ?></td></tr>
+        <tr><th><?php _e( 'Tax', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $quote->tax_total ); ?></td></tr>
+        <tr><th><?php _e( 'Shipping', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $quote->shipping_total ); ?></td></tr>
+        <tr><th><?php _e( 'Grand Total', 'bwk-accounting-lite' ); ?></th><td><?php echo esc_html( $quote->grand_total ); ?></td></tr>
+    </table>
+    <footer>
+        <p><?php echo nl2br( esc_html( $quote->notes ) ); ?></p>
+    </footer>
+</div>
+<script src="<?php echo esc_url( BWK_AL_URL . 'public/js/public.js' ); ?>"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce dedicated quote tables and number generation helpers
- add quotes CRUD class with REST endpoint and conversion to invoices
- provide admin screens and front-end template for managing and printing quotes

## Testing
- `php -l includes/helpers.php`
- `php -l includes/class-activator.php`
- `php -l includes/class-quotes-table.php`
- `php -l includes/class-admin-menu.php`
- `php -l bwk-accounting-lite.php`
- `php -l admin/views-quotes-list.php`
- `php -l admin/views-quote-edit.php`
- `php -l public/templates/quote-a4.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf8def85c08330b4d56b9f0006fa6d