### PR TITLE
Integrate WooCommerce product search for invoice and quote items

### DIFF
--- a/bwk-accounting-lite/admin/css/admin.css
+++ b/bwk-accounting-lite/admin/css/admin.css
@@ -1,4 +1,12 @@
 /* Admin styles for BWK Accounting Lite */
 #bwk-items-table input { width: 100%; }
+#bwk-items-table .bwk-item-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+#bwk-items-table .select2-container {
+    width: 100% !important;
+}
 #bwk-items-table .bwk-line-total { text-align: right; }
 .wrap .widefat td { vertical-align: top; }

--- a/bwk-accounting-lite/admin/js/admin.js
+++ b/bwk-accounting-lite/admin/js/admin.js
@@ -1,26 +1,135 @@
 jQuery(function($){
+    var settings = window.bwkAdmin || {};
+    var searchPlaceholder = settings.i18nSearchProducts || 'Search for a product…';
+    var itemPlaceholder = settings.i18nItemName || '';
+
+    function createItemRow() {
+        var $row = $('<tr/>');
+        var $itemCell = $('<td/>');
+        var $itemWrapper = $('<div/>', { 'class': 'bwk-item-field' });
+        var $productSelect = $('<select/>', {
+            'class': 'bwk-product-search',
+            name: 'product_id[]',
+            'data-placeholder': searchPlaceholder,
+            'data-allow_clear': 'true',
+            'data-action': 'woocommerce_json_search_products_and_variations',
+            style: 'width: 100%;'
+        });
+
+        $itemWrapper.append($productSelect);
+        $itemWrapper.append(
+            $('<input/>', {
+                type: 'text',
+                name: 'item_name[]',
+                'class': 'bwk-item-name',
+                autocomplete: 'off',
+                placeholder: itemPlaceholder
+            })
+        );
+
+        $itemCell.append($itemWrapper);
+        $row.append($itemCell);
+
+        $row.append(
+            $('<td/>').append(
+                $('<input/>', {
+                    type: 'number',
+                    step: '0.01',
+                    name: 'qty[]',
+                    'class': 'bwk-qty'
+                })
+            )
+        );
+
+        $row.append(
+            $('<td/>').append(
+                $('<input/>', {
+                    type: 'number',
+                    step: '0.01',
+                    name: 'unit_price[]',
+                    'class': 'bwk-price'
+                })
+            )
+        );
+
+        $row.append($('<td/>', { 'class': 'bwk-line-total', text: '0.00' }));
+        $row.append(
+            $('<td/>').append(
+                $('<button/>', {
+                    type: 'button',
+                    'class': 'button bwk-remove',
+                    text: '×'
+                })
+            )
+        );
+
+        return $row;
+    }
+
     $('#bwk-add-row').on('click', function(){
-        var row = '<tr><td><input type="text" name="item_name[]" /></td><td><input type="number" step="0.01" name="qty[]" class="bwk-qty" /></td><td><input type="number" step="0.01" name="unit_price[]" class="bwk-price" /></td><td class="bwk-line-total">0</td><td><button type="button" class="button bwk-remove">&times;</button></td></tr>';
-        $('#bwk-items-table tbody').append(row);
+        var $row = createItemRow();
+        $('#bwk-items-table tbody').append($row);
+        $(document.body).trigger('wc-enhanced-select-init');
+        updateTotals();
     });
-    $(document).on('click','.bwk-remove',function(){
+
+    $(document).on('click', '.bwk-remove', function(){
         $(this).closest('tr').remove();
+        updateTotals();
     });
+
     function updateTotals(){
-        var subtotal=0;
+        var subtotal = 0;
         $('#bwk-items-table tbody tr').each(function(){
-            var qty=parseFloat($(this).find('.bwk-qty').val())||0;
-            var price=parseFloat($(this).find('.bwk-price').val())||0;
-            var total=qty*price;
+            var qty = parseFloat($(this).find('.bwk-qty').val()) || 0;
+            var price = parseFloat($(this).find('.bwk-price').val()) || 0;
+            var total = qty * price;
             $(this).find('.bwk-line-total').text(total.toFixed(2));
-            subtotal+=total;
+            subtotal += total;
         });
         $('#subtotal').val(subtotal.toFixed(2));
-        var discount=parseFloat($('#discount_total').val())||0;
-        var tax=parseFloat($('#tax_total').val())||0;
-        var shipping=parseFloat($('#shipping_total').val())||0;
-        var grand=subtotal-discount+tax+shipping;
+        var discount = parseFloat($('#discount_total').val()) || 0;
+        var tax = parseFloat($('#tax_total').val()) || 0;
+        var shipping = parseFloat($('#shipping_total').val()) || 0;
+        var grand = subtotal - discount + tax + shipping;
         $('#grand_total').val(grand.toFixed(2));
     }
-    $(document).on('input','.bwk-qty,.bwk-price,#discount_total,#tax_total,#shipping_total',updateTotals);
+
+    $(document).on('input', '.bwk-qty,.bwk-price,#discount_total,#tax_total,#shipping_total', updateTotals);
+
+    $(document).on('change', '.bwk-product-search', function(){
+        var productId = $(this).val();
+        var $row = $(this).closest('tr');
+
+        if (!productId || !settings.ajaxUrl) {
+            return;
+        }
+
+        $.ajax({
+            url: settings.ajaxUrl,
+            method: 'POST',
+            dataType: 'json',
+            data: {
+                action: 'bwk_wc_product_details',
+                product_id: productId,
+                nonce: settings.productNonce || ''
+            }
+        }).done(function(response){
+            if (response && response.success && response.data) {
+                if (typeof response.data.name !== 'undefined') {
+                    $row.find('.bwk-item-name').val(response.data.name);
+                }
+                if (typeof response.data.price !== 'undefined' && response.data.price !== null) {
+                    $row.find('.bwk-price').val(response.data.price);
+                }
+                updateTotals();
+            }
+        }).fail(function(){
+            if ( window.console && window.console.error ) {
+                window.console.error('Unable to load product details for invoice item.');
+            }
+        });
+    });
+
+    $(document.body).trigger('wc-enhanced-select-init');
 });

--- a/bwk-accounting-lite/admin/views-invoice-edit.php
+++ b/bwk-accounting-lite/admin/views-invoice-edit.php
@@ -31,13 +31,40 @@ $invoice_id = $invoice ? intval( $invoice->id ) : 0;
             <thead><tr><th><?php _e( 'Item', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Qty', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Unit Price', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Line Total', 'bwk-accounting-lite' ); ?></th><th>&nbsp;</th></tr></thead>
             <tbody>
                 <?php
+                $search_placeholder = esc_attr__( 'Search for a product…', 'bwk-accounting-lite' );
+                $item_placeholder   = esc_attr__( 'Item name', 'bwk-accounting-lite' );
                 if ( $items ) {
                     foreach ( $items as $it ) {
-                        echo '<tr><td><input type="text" name="item_name[]" value="' . esc_attr( $it->item_name ) . '" /></td>';
-                        echo '<td><input type="number" step="0.01" name="qty[]" value="' . esc_attr( $it->qty ) . '" class="bwk-qty" /></td>';
-                        echo '<td><input type="number" step="0.01" name="unit_price[]" value="' . esc_attr( $it->unit_price ) . '" class="bwk-price" /></td>';
-                        echo '<td class="bwk-line-total">' . esc_html( $it->line_total ) . '</td><td><button type="button" class="button bwk-remove">&times;</button></td></tr>';
+                        ?>
+                        <tr>
+                            <td>
+                                <div class="bwk-item-field">
+                                    <select class="bwk-product-search" name="product_id[]" data-placeholder="<?php echo $search_placeholder; ?>" data-allow_clear="true" data-action="woocommerce_json_search_products_and_variations" style="width: 100%;"></select>
+                                    <input type="text" name="item_name[]" class="bwk-item-name" value="<?php echo esc_attr( $it->item_name ); ?>" placeholder="<?php echo $item_placeholder; ?>" autocomplete="off" />
+                                </div>
+                            </td>
+                            <td><input type="number" step="0.01" name="qty[]" value="<?php echo esc_attr( $it->qty ); ?>" class="bwk-qty" /></td>
+                            <td><input type="number" step="0.01" name="unit_price[]" value="<?php echo esc_attr( $it->unit_price ); ?>" class="bwk-price" /></td>
+                            <td class="bwk-line-total"><?php echo esc_html( number_format_i18n( (float) $it->line_total, 2 ) ); ?></td>
+                            <td><button type="button" class="button bwk-remove">&times;</button></td>
+                        </tr>
+                        <?php
                     }
+                } else {
+                    ?>
+                    <tr>
+                        <td>
+                            <div class="bwk-item-field">
+                                <select class="bwk-product-search" name="product_id[]" data-placeholder="<?php echo $search_placeholder; ?>" data-allow_clear="true" data-action="woocommerce_json_search_products_and_variations" style="width: 100%;"></select>
+                                <input type="text" name="item_name[]" class="bwk-item-name" value="" placeholder="<?php echo $item_placeholder; ?>" autocomplete="off" />
+                            </div>
+                        </td>
+                        <td><input type="number" step="0.01" name="qty[]" value="" class="bwk-qty" /></td>
+                        <td><input type="number" step="0.01" name="unit_price[]" value="" class="bwk-price" /></td>
+                        <td class="bwk-line-total"><?php echo esc_html( number_format_i18n( 0, 2 ) ); ?></td>
+                        <td><button type="button" class="button bwk-remove">&times;</button></td>
+                    </tr>
+                    <?php
                 }
                 ?>
             </tbody>

--- a/bwk-accounting-lite/admin/views-quote-edit.php
+++ b/bwk-accounting-lite/admin/views-quote-edit.php
@@ -31,13 +31,40 @@ $quote_id = $quote ? intval( $quote->id ) : 0;
             <thead><tr><th><?php _e( 'Item', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Qty', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Unit Price', 'bwk-accounting-lite' ); ?></th><th><?php _e( 'Line Total', 'bwk-accounting-lite' ); ?></th><th>&nbsp;</th></tr></thead>
             <tbody>
                 <?php
+                $search_placeholder = esc_attr__( 'Search for a product…', 'bwk-accounting-lite' );
+                $item_placeholder   = esc_attr__( 'Item name', 'bwk-accounting-lite' );
                 if ( $items ) {
                     foreach ( $items as $it ) {
-                        echo '<tr><td><input type="text" name="item_name[]" value="' . esc_attr( $it->item_name ) . '" /></td>';
-                        echo '<td><input type="number" step="0.01" name="qty[]" value="' . esc_attr( $it->qty ) . '" class="bwk-qty" /></td>';
-                        echo '<td><input type="number" step="0.01" name="unit_price[]" value="' . esc_attr( $it->unit_price ) . '" class="bwk-price" /></td>';
-                        echo '<td class="bwk-line-total">' . esc_html( $it->line_total ) . '</td><td><button type="button" class="button bwk-remove">&times;</button></td></tr>';
+                        ?>
+                        <tr>
+                            <td>
+                                <div class="bwk-item-field">
+                                    <select class="bwk-product-search" name="product_id[]" data-placeholder="<?php echo $search_placeholder; ?>" data-allow_clear="true" data-action="woocommerce_json_search_products_and_variations" style="width: 100%;"></select>
+                                    <input type="text" name="item_name[]" class="bwk-item-name" value="<?php echo esc_attr( $it->item_name ); ?>" placeholder="<?php echo $item_placeholder; ?>" autocomplete="off" />
+                                </div>
+                            </td>
+                            <td><input type="number" step="0.01" name="qty[]" value="<?php echo esc_attr( $it->qty ); ?>" class="bwk-qty" /></td>
+                            <td><input type="number" step="0.01" name="unit_price[]" value="<?php echo esc_attr( $it->unit_price ); ?>" class="bwk-price" /></td>
+                            <td class="bwk-line-total"><?php echo esc_html( number_format_i18n( (float) $it->line_total, 2 ) ); ?></td>
+                            <td><button type="button" class="button bwk-remove">&times;</button></td>
+                        </tr>
+                        <?php
                     }
+                } else {
+                    ?>
+                    <tr>
+                        <td>
+                            <div class="bwk-item-field">
+                                <select class="bwk-product-search" name="product_id[]" data-placeholder="<?php echo $search_placeholder; ?>" data-allow_clear="true" data-action="woocommerce_json_search_products_and_variations" style="width: 100%;"></select>
+                                <input type="text" name="item_name[]" class="bwk-item-name" value="" placeholder="<?php echo $item_placeholder; ?>" autocomplete="off" />
+                            </div>
+                        </td>
+                        <td><input type="number" step="0.01" name="qty[]" value="" class="bwk-qty" /></td>
+                        <td><input type="number" step="0.01" name="unit_price[]" value="" class="bwk-price" /></td>
+                        <td class="bwk-line-total"><?php echo esc_html( number_format_i18n( 0, 2 ) ); ?></td>
+                        <td><button type="button" class="button bwk-remove">&times;</button></td>
+                    </tr>
+                    <?php
                 }
                 ?>
             </tbody>

--- a/bwk-accounting-lite/includes/class-admin-menu.php
+++ b/bwk-accounting-lite/includes/class-admin-menu.php
@@ -29,8 +29,27 @@ class BWK_Admin_Menu {
         if ( strpos( $hook, 'bwk' ) === false ) {
             return;
         }
+        $deps = array( 'jquery' );
+
+        if ( class_exists( 'WooCommerce' ) ) {
+            wp_enqueue_style( 'woocommerce_admin_styles' );
+            wp_enqueue_script( 'wc-product-search' );
+            $deps[] = 'wc-product-search';
+        }
+
         wp_enqueue_style( 'bwk-admin', BWK_AL_URL . 'admin/css/admin.css', array(), BWK_AL_VERSION );
-        wp_enqueue_script( 'bwk-admin', BWK_AL_URL . 'admin/js/admin.js', array( 'jquery' ), BWK_AL_VERSION, true );
+        wp_enqueue_script( 'bwk-admin', BWK_AL_URL . 'admin/js/admin.js', $deps, BWK_AL_VERSION, true );
+
+        wp_localize_script(
+            'bwk-admin',
+            'bwkAdmin',
+            array(
+                'ajaxUrl'            => admin_url( 'admin-ajax.php' ),
+                'productNonce'       => wp_create_nonce( 'bwk_wc_product_details' ),
+                'i18nSearchProducts' => __( 'Search for a product…', 'bwk-accounting-lite' ),
+                'i18nItemName'       => __( 'Item name', 'bwk-accounting-lite' ),
+            )
+        );
     }
     public static function admin_bar($wp_admin_bar) {
         if ( ! bwk_current_user_can() ) {

--- a/bwk-accounting-lite/includes/class-ajax.php
+++ b/bwk-accounting-lite/includes/class-ajax.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BWK_Ajax {
     public static function init() {
         add_action( 'wp_ajax_bwk_import_wc_orders', array( __CLASS__, 'import_wc_orders' ) );
+        add_action( 'wp_ajax_bwk_wc_product_details', array( __CLASS__, 'get_wc_product_details' ) );
     }
 
     public static function import_wc_orders() {
@@ -19,5 +20,46 @@ class BWK_Ajax {
         check_ajax_referer( 'bwk_import_wc_orders' );
         // Stub - actual import would run in batches.
         wp_send_json_success( array( 'done' => true ) );
+    }
+
+    public static function get_wc_product_details() {
+        if ( ! bwk_current_user_can() ) {
+            wp_send_json_error( array( 'message' => __( 'You do not have permission to access product data.', 'bwk-accounting-lite' ) ) );
+        }
+
+        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+        if ( ! wp_verify_nonce( $nonce, 'bwk_wc_product_details' ) ) {
+            wp_send_json_error( array( 'message' => __( 'Invalid request. Please refresh and try again.', 'bwk-accounting-lite' ) ) );
+        }
+
+        $product_id = isset( $_POST['product_id'] ) ? absint( wp_unslash( $_POST['product_id'] ) ) : 0;
+        if ( ! $product_id ) {
+            wp_send_json_error( array( 'message' => __( 'Invalid product selection.', 'bwk-accounting-lite' ) ) );
+        }
+
+        if ( ! function_exists( 'wc_get_product' ) ) {
+            wp_send_json_error( array( 'message' => __( 'WooCommerce is required for product search.', 'bwk-accounting-lite' ) ) );
+        }
+
+        $product = wc_get_product( $product_id );
+        if ( ! $product ) {
+            wp_send_json_error( array( 'message' => __( 'Product not found.', 'bwk-accounting-lite' ) ) );
+        }
+
+        $price = function_exists( 'wc_get_price_to_display' ) ? wc_get_price_to_display( $product ) : $product->get_price();
+
+        if ( function_exists( 'wc_format_decimal' ) && function_exists( 'wc_get_price_decimals' ) ) {
+            $formatted = wc_format_decimal( $price, wc_get_price_decimals() );
+        } else {
+            $formatted = is_numeric( $price ) ? (string) $price : '';
+        }
+
+        wp_send_json_success(
+            array(
+                'id'    => $product_id,
+                'name'  => $product->get_name(),
+                'price' => $formatted,
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- replace invoice and quote item fields with a WooCommerce-powered product search and fall back text inputs
- enhance admin JavaScript and styles to initialise the product selector, populate item data from WooCommerce, and keep totals in sync
- enqueue WooCommerce product search assets and expose an authenticated AJAX endpoint for retrieving product pricing

## Testing
- php -l bwk-accounting-lite/admin/views-invoice-edit.php
- php -l bwk-accounting-lite/admin/views-quote-edit.php
- php -l bwk-accounting-lite/includes/class-ajax.php
- php -l bwk-accounting-lite/includes/class-admin-menu.php

------
https://chatgpt.com/codex/tasks/task_e_68c8b95174c08330ade8d3a7a94d97a8