### PR TITLE
Add invoice number preview helper

### DIFF
--- a/bwk-accounting-lite/admin/views-invoice-edit.php
+++ b/bwk-accounting-lite/admin/views-invoice-edit.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 $invoice_id = $invoice ? intval( $invoice->id ) : 0;
+$number_value = $invoice ? $invoice->number : $next_invoice_number;
 ?>
 <div class="wrap">
     <h1><?php echo $invoice_id ? esc_html__( 'Edit Invoice', 'bwk-accounting-lite' ) : esc_html__( 'Add Invoice', 'bwk-accounting-lite' ); ?></h1>
@@ -12,7 +13,7 @@ $invoice_id = $invoice ? intval( $invoice->id ) : 0;
         <input type="hidden" name="invoice_id" value="<?php echo esc_attr( $invoice_id ); ?>" />
         <table class="form-table">
             <tr><th><label for="number"><?php _e( 'Number', 'bwk-accounting-lite' ); ?></label></th>
-            <td><input name="number" id="number" type="text" value="<?php echo esc_attr( $invoice ? $invoice->number : '' ); ?>" class="regular-text" /></td></tr>
+            <td><input name="number" id="number" type="text" value="<?php echo esc_attr( $number_value ); ?>" class="regular-text" /></td></tr>
             <tr><th><label for="status"><?php _e( 'Status', 'bwk-accounting-lite' ); ?></label></th>
             <td><select name="status" id="status">
                 <?php foreach ( array( 'draft','sent','paid','partial','void' ) as $st ) : ?>

--- a/bwk-accounting-lite/includes/class-invoices-tables.php
+++ b/bwk-accounting-lite/includes/class-invoices-tables.php
@@ -36,6 +36,10 @@ class BWK_Invoices {
             $invoice = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_invoices() . ' WHERE id=%d', $id ) );
             $items   = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_invoice_items() . ' WHERE invoice_id=%d ORDER BY line_no ASC', $id ) );
         }
+        $next_invoice_number = null;
+        if ( ! $invoice ) {
+            $next_invoice_number = bwk_preview_invoice_number();
+        }
         include BWK_AL_PATH . 'admin/views-invoice-edit.php';
     }
 

--- a/bwk-accounting-lite/includes/helpers.php
+++ b/bwk-accounting-lite/includes/helpers.php
@@ -52,6 +52,14 @@ function bwk_next_invoice_number() {
     return $prefix . str_pad( (string) $seq, $pad, '0', STR_PAD_LEFT );
 }
 
+function bwk_preview_invoice_number() {
+    $seq = (int) bwk_get_option( 'invoice_seq', 0 );
+    $seq++;
+    $prefix = bwk_get_option( 'number_prefix', 'INV-' );
+    $pad    = (int) bwk_get_option( 'number_padding', 4 );
+    return $prefix . str_pad( (string) $seq, $pad, '0', STR_PAD_LEFT );
+}
+
 function bwk_next_quote_number() {
     $seq = (int) bwk_get_option( 'quote_seq', 0 );
     $seq++;


### PR DESCRIPTION
## Summary
- add a helper that formats the next invoice number without advancing the sequence
- compute the preview number when rendering a new invoice form and pass it to the template
- prefill the invoice number input with the preview when creating a new invoice

## Testing
- php -l bwk-accounting-lite/includes/helpers.php
- php -l bwk-accounting-lite/includes/class-invoices-tables.php
- php -l bwk-accounting-lite/admin/views-invoice-edit.php

------
https://chatgpt.com/codex/tasks/task_e_68cee555201483309ecf012b46528120