### PR TITLE
Add WooCommerce product picker for invoice and quote items

### DIFF
--- a/bwk-accounting-lite/admin/css/admin.css
+++ b/bwk-accounting-lite/admin/css/admin.css
@@ -2,3 +2,9 @@
 #bwk-items-table input { width: 100%; }
 #bwk-items-table .bwk-line-total { text-align: right; }
 .wrap .widefat td { vertical-align: top; }
+#bwk-items-table .bwk-product-toggle { margin-top: 4px; }
+#bwk-items-table .bwk-product-picker { display: none; margin-top: 6px; }
+#bwk-items-table .bwk-product-picker.is-active { display: block; }
+#bwk-items-table .bwk-product-search,
+#bwk-items-table .bwk-product-select { width: 100%; }
+#bwk-items-table .bwk-product-search { margin-bottom: 4px; }

--- a/bwk-accounting-lite/admin/js/admin.js
+++ b/bwk-accounting-lite/admin/js/admin.js
@@ -1,26 +1,220 @@
 jQuery(function($){
-    $('#bwk-add-row').on('click', function(){
-        var row = '<tr><td><input type="text" name="item_name[]" /><input type="hidden" class="bwk-product-id" name="product_id[]" value="" /><input type="hidden" class="bwk-product-sku" name="product_sku[]" value="" /></td><td><input type="number" step="0.01" name="qty[]" class="bwk-qty" /></td><td><input type="number" step="0.01" name="unit_price[]" class="bwk-price" /></td><td class="bwk-line-total">0</td><td><button type="button" class="button bwk-remove">&times;</button></td></tr>';
-        $('#bwk-items-table tbody').append(row);
-    });
-    $(document).on('click','.bwk-remove',function(){
-        $(this).closest('tr').remove();
-    });
+    var settings = window.bwkAdminData || {};
+    settings.i18n = settings.i18n || {};
+    var productsEnabled = settings.productsEnabled !== false;
+
+    function htmlEscape(str) {
+        return String(str === undefined ? '' : str)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+
+    function rowTemplate() {
+        var label = htmlEscape(settings.i18n.useProductLabel || 'Use existing product');
+        var placeholder = htmlEscape(settings.i18n.searchPlaceholder || 'Search for a product…');
+        var help = htmlEscape(settings.i18n.searchHelp || 'Start typing to search WooCommerce products.');
+        var prompt = htmlEscape(settings.i18n.selectPrompt || 'Select a product');
+        return '<tr class="bwk-item-row">'
+            + '<td>'
+            + '<input type="text" name="item_name[]" />'
+            + '<input type="hidden" class="bwk-product-id" name="product_id[]" value="" />'
+            + '<input type="hidden" class="bwk-product-sku" name="product_sku[]" value="" />'
+            + '<div class="bwk-product-toggle">'
+            + '<label><input type="checkbox" class="bwk-use-product" /> ' + label + '</label>'
+            + '<div class="bwk-product-picker">'
+            + '<input type="search" class="bwk-product-search" placeholder="' + placeholder + '" />'
+            + '<select class="bwk-product-select">'
+            + ( prompt ? '<option value="">' + prompt + '</option>' : '' )
+            + '</select>'
+            + ( help ? '<p class="description">' + help + '</p>' : '' )
+            + '</div>'
+            + '</div>'
+            + '</td>'
+            + '<td><input type="number" step="0.01" name="qty[]" class="bwk-qty" /></td>'
+            + '<td><input type="number" step="0.01" name="unit_price[]" class="bwk-price" /></td>'
+            + '<td class="bwk-line-total">0</td>'
+            + '<td><button type="button" class="button bwk-remove">&times;</button></td>'
+            + '</tr>';
+    }
+
     function updateTotals(){
-        var subtotal=0;
+        var subtotal = 0;
         $('#bwk-items-table tbody tr').each(function(){
-            var qty=parseFloat($(this).find('.bwk-qty').val())||0;
-            var price=parseFloat($(this).find('.bwk-price').val())||0;
-            var total=qty*price;
-            $(this).find('.bwk-line-total').text(total.toFixed(2));
-            subtotal+=total;
+            var $row = $(this);
+            var qty = parseFloat($row.find('.bwk-qty').val()) || 0;
+            var price = parseFloat($row.find('.bwk-price').val()) || 0;
+            var total = qty * price;
+            $row.find('.bwk-line-total').text(total.toFixed(2));
+            subtotal += total;
         });
         $('#subtotal').val(subtotal.toFixed(2));
-        var discount=parseFloat($('#discount_total').val())||0;
-        var tax=parseFloat($('#tax_total').val())||0;
-        var shipping=parseFloat($('#shipping_total').val())||0;
-        var grand=subtotal-discount+tax+shipping;
+        var discount = parseFloat($('#discount_total').val()) || 0;
+        var tax = parseFloat($('#tax_total').val()) || 0;
+        var shipping = parseFloat($('#shipping_total').val()) || 0;
+        var grand = subtotal - discount + tax + shipping;
         $('#grand_total').val(grand.toFixed(2));
     }
+
+    function togglePicker($row, show) {
+        var $picker = $row.find('.bwk-product-picker');
+        if ( show ) {
+            $picker.addClass('is-active');
+        } else {
+            $picker.removeClass('is-active');
+        }
+    }
+
+    function resetSelect($select) {
+        $select.empty();
+        var prompt = settings.i18n.selectPrompt || 'Select a product';
+        if ( prompt ) {
+            $select.append($('<option>').val('').text(prompt));
+        }
+    }
+
+    function setSelectMessage($select, message) {
+        $select.empty();
+        if ( message ) {
+            $select.append($('<option>').val('').text(message).prop('disabled', true));
+        }
+    }
+
+    function populateSelect($select, items) {
+        resetSelect($select);
+        if (!items || !items.length) {
+            if ( settings.i18n.noResults ) {
+                $select.append($('<option>').val('').text(settings.i18n.noResults).prop('disabled', true));
+            }
+            return;
+        }
+        $.each(items, function(_, item){
+            var id = item.id;
+            if (!id) {
+                return;
+            }
+            var name = item.name || '';
+            var sku = item.sku || '';
+            var label = name;
+            if ( sku ) {
+                label += ' (' + sku + ')';
+            }
+            var $option = $('<option>').val(id).text(label).attr('data-name', name);
+            if ( sku ) {
+                $option.attr('data-sku', sku);
+            }
+            if ( item.price !== undefined && item.price !== null && item.price !== '' ) {
+                $option.attr('data-price', item.price);
+            }
+            $select.append($option);
+        });
+    }
+
+    function resetProductFields($row) {
+        $row.find('.bwk-product-id').val('');
+        $row.find('.bwk-product-sku').val('');
+    }
+
+    function fetchProducts(term, $select) {
+        if ( ! settings.ajaxUrl || ! settings.searchNonce ) {
+            return;
+        }
+        setSelectMessage($select, settings.i18n.searching || 'Searching…');
+        $.ajax({
+            url: settings.ajaxUrl,
+            method: 'GET',
+            dataType: 'json',
+            data: {
+                action: 'bwk_search_products',
+                nonce: settings.searchNonce,
+                term: term
+            }
+        }).done(function(response){
+            if ( response && response.success && response.data && response.data.items ) {
+                populateSelect($select, response.data.items);
+            } else {
+                setSelectMessage($select, settings.i18n.error || 'Unable to load products.');
+            }
+        }).fail(function(){
+            setSelectMessage($select, settings.i18n.error || 'Unable to load products.');
+        });
+    }
+
+    $('#bwk-add-row').on('click', function(){
+        $('#bwk-items-table tbody').append(rowTemplate());
+    });
+
+    $(document).on('click','.bwk-remove',function(){
+        $(this).closest('tr').remove();
+        updateTotals();
+    });
+
+    $(document).on('change', '.bwk-use-product', function(){
+        var $checkbox = $(this);
+        var $row = $checkbox.closest('tr');
+        if ( $checkbox.is(':checked') ) {
+            if ( ! productsEnabled ) {
+                if ( settings.i18n.noWooCommerce ) {
+                    window.alert(settings.i18n.noWooCommerce);
+                }
+                $checkbox.prop('checked', false);
+                return;
+            }
+            togglePicker($row, true);
+            $row.find('.bwk-product-search').trigger('focus');
+        } else {
+            togglePicker($row, false);
+            resetProductFields($row);
+            resetSelect($row.find('.bwk-product-select'));
+        }
+    });
+
+    $(document).on('input', '.bwk-product-search', function(){
+        var $input = $(this);
+        var $row = $input.closest('tr');
+        var $select = $row.find('.bwk-product-select');
+        var term = $.trim($input.val());
+        var timerId = $input.data('bwkTimer');
+        if ( timerId ) {
+            window.clearTimeout(timerId);
+        }
+        if ( term.length < 2 ) {
+            resetSelect($select);
+            $input.data('bwkTimer', null);
+            return;
+        }
+        var newTimer = window.setTimeout(function(){
+            fetchProducts(term, $select);
+        }, 300);
+        $input.data('bwkTimer', newTimer);
+    });
+
+    $(document).on('change', '.bwk-product-select', function(){
+        var $select = $(this);
+        var $row = $select.closest('tr');
+        var productId = parseInt($select.val(), 10);
+        if ( ! productId ) {
+            return;
+        }
+        var $option = $select.find('option:selected');
+        var name = $option.data('name') || '';
+        var price = parseFloat($option.data('price'));
+        var sku = $option.data('sku') || '';
+        if ( name ) {
+            $row.find('input[name="item_name[]"]').val(name);
+        }
+        if ( ! isNaN(price) ) {
+            $row.find('input[name="unit_price[]"]').val(price.toFixed(2));
+        }
+        var $qty = $row.find('.bwk-qty');
+        if ( ! $qty.val() ) {
+            $qty.val('1');
+        }
+        $row.find('.bwk-product-id').val(productId);
+        $row.find('.bwk-product-sku').val(sku);
+        updateTotals();
+    });
+
     $(document).on('input','.bwk-qty,.bwk-price,#discount_total,#tax_total,#shipping_total',updateTotals);
 });

--- a/bwk-accounting-lite/admin/views-invoice-edit.php
+++ b/bwk-accounting-lite/admin/views-invoice-edit.php
@@ -33,16 +33,48 @@ $invoice_id = $invoice ? intval( $invoice->id ) : 0;
                 <?php
                 if ( $items ) {
                     foreach ( $items as $it ) {
-                        $product_id  = $it->product_id ? absint( $it->product_id ) : '';
-                        $product_sku = $it->product_sku ? $it->product_sku : '';
-                        echo '<tr>';
-                        echo '<td><input type="text" name="item_name[]" value="' . esc_attr( $it->item_name ) . '" />';
-                        echo '<input type="hidden" class="bwk-product-id" name="product_id[]" value="' . esc_attr( $product_id ) . '" />';
-                        echo '<input type="hidden" class="bwk-product-sku" name="product_sku[]" value="' . esc_attr( $product_sku ) . '" /></td>';
-                        echo '<td><input type="number" step="0.01" name="qty[]" value="' . esc_attr( $it->qty ) . '" class="bwk-qty" /></td>';
-                        echo '<td><input type="number" step="0.01" name="unit_price[]" value="' . esc_attr( $it->unit_price ) . '" class="bwk-price" /></td>';
-                        echo '<td class="bwk-line-total">' . esc_html( $it->line_total ) . '</td><td><button type="button" class="button bwk-remove">&times;</button></td>';
-                        echo '</tr>';
+                        $product_id       = $it->product_id ? absint( $it->product_id ) : '';
+                        $product_sku      = $it->product_sku ? $it->product_sku : '';
+                        $picker_classes   = 'bwk-product-picker';
+                        $option_label     = $it->item_name;
+                        $product_selected = ! empty( $product_id );
+
+                        if ( $product_selected ) {
+                            $picker_classes .= ' is-active';
+                        }
+
+                        if ( $product_sku ) {
+                            $option_label .= ' (' . $product_sku . ')';
+                        }
+                        ?>
+                        <tr class="bwk-item-row">
+                            <td>
+                                <input type="text" name="item_name[]" value="<?php echo esc_attr( $it->item_name ); ?>" />
+                                <input type="hidden" class="bwk-product-id" name="product_id[]" value="<?php echo esc_attr( $product_id ); ?>" />
+                                <input type="hidden" class="bwk-product-sku" name="product_sku[]" value="<?php echo esc_attr( $product_sku ); ?>" />
+                                <div class="bwk-product-toggle">
+                                    <label>
+                                        <input type="checkbox" class="bwk-use-product" <?php checked( $product_selected ); ?> />
+                                        <?php esc_html_e( 'Use existing product', 'bwk-accounting-lite' ); ?>
+                                    </label>
+                                    <div class="<?php echo esc_attr( $picker_classes ); ?>">
+                                        <input type="search" class="bwk-product-search" placeholder="<?php esc_attr_e( 'Search for a product…', 'bwk-accounting-lite' ); ?>" />
+                                        <select class="bwk-product-select">
+                                            <option value=""><?php esc_html_e( 'Select a product', 'bwk-accounting-lite' ); ?></option>
+                                            <?php if ( $product_selected ) : ?>
+                                                <option value="<?php echo esc_attr( $product_id ); ?>" data-name="<?php echo esc_attr( $it->item_name ); ?>" data-price="<?php echo esc_attr( $it->unit_price ); ?>" data-sku="<?php echo esc_attr( $product_sku ); ?>" selected><?php echo esc_html( $option_label ); ?></option>
+                                            <?php endif; ?>
+                                        </select>
+                                        <p class="description"><?php esc_html_e( 'Start typing to search WooCommerce products.', 'bwk-accounting-lite' ); ?></p>
+                                    </div>
+                                </div>
+                            </td>
+                            <td><input type="number" step="0.01" name="qty[]" value="<?php echo esc_attr( $it->qty ); ?>" class="bwk-qty" /></td>
+                            <td><input type="number" step="0.01" name="unit_price[]" value="<?php echo esc_attr( $it->unit_price ); ?>" class="bwk-price" /></td>
+                            <td class="bwk-line-total"><?php echo esc_html( $it->line_total ); ?></td>
+                            <td><button type="button" class="button bwk-remove">&times;</button></td>
+                        </tr>
+                        <?php
                     }
                 }
                 ?>

--- a/bwk-accounting-lite/admin/views-quote-edit.php
+++ b/bwk-accounting-lite/admin/views-quote-edit.php
@@ -33,16 +33,48 @@ $quote_id = $quote ? intval( $quote->id ) : 0;
                 <?php
                 if ( $items ) {
                     foreach ( $items as $it ) {
-                        $product_id  = $it->product_id ? absint( $it->product_id ) : '';
-                        $product_sku = $it->product_sku ? $it->product_sku : '';
-                        echo '<tr>';
-                        echo '<td><input type="text" name="item_name[]" value="' . esc_attr( $it->item_name ) . '" />';
-                        echo '<input type="hidden" class="bwk-product-id" name="product_id[]" value="' . esc_attr( $product_id ) . '" />';
-                        echo '<input type="hidden" class="bwk-product-sku" name="product_sku[]" value="' . esc_attr( $product_sku ) . '" /></td>';
-                        echo '<td><input type="number" step="0.01" name="qty[]" value="' . esc_attr( $it->qty ) . '" class="bwk-qty" /></td>';
-                        echo '<td><input type="number" step="0.01" name="unit_price[]" value="' . esc_attr( $it->unit_price ) . '" class="bwk-price" /></td>';
-                        echo '<td class="bwk-line-total">' . esc_html( $it->line_total ) . '</td><td><button type="button" class="button bwk-remove">&times;</button></td>';
-                        echo '</tr>';
+                        $product_id       = $it->product_id ? absint( $it->product_id ) : '';
+                        $product_sku      = $it->product_sku ? $it->product_sku : '';
+                        $picker_classes   = 'bwk-product-picker';
+                        $option_label     = $it->item_name;
+                        $product_selected = ! empty( $product_id );
+
+                        if ( $product_selected ) {
+                            $picker_classes .= ' is-active';
+                        }
+
+                        if ( $product_sku ) {
+                            $option_label .= ' (' . $product_sku . ')';
+                        }
+                        ?>
+                        <tr class="bwk-item-row">
+                            <td>
+                                <input type="text" name="item_name[]" value="<?php echo esc_attr( $it->item_name ); ?>" />
+                                <input type="hidden" class="bwk-product-id" name="product_id[]" value="<?php echo esc_attr( $product_id ); ?>" />
+                                <input type="hidden" class="bwk-product-sku" name="product_sku[]" value="<?php echo esc_attr( $product_sku ); ?>" />
+                                <div class="bwk-product-toggle">
+                                    <label>
+                                        <input type="checkbox" class="bwk-use-product" <?php checked( $product_selected ); ?> />
+                                        <?php esc_html_e( 'Use existing product', 'bwk-accounting-lite' ); ?>
+                                    </label>
+                                    <div class="<?php echo esc_attr( $picker_classes ); ?>">
+                                        <input type="search" class="bwk-product-search" placeholder="<?php esc_attr_e( 'Search for a product…', 'bwk-accounting-lite' ); ?>" />
+                                        <select class="bwk-product-select">
+                                            <option value=""><?php esc_html_e( 'Select a product', 'bwk-accounting-lite' ); ?></option>
+                                            <?php if ( $product_selected ) : ?>
+                                                <option value="<?php echo esc_attr( $product_id ); ?>" data-name="<?php echo esc_attr( $it->item_name ); ?>" data-price="<?php echo esc_attr( $it->unit_price ); ?>" data-sku="<?php echo esc_attr( $product_sku ); ?>" selected><?php echo esc_html( $option_label ); ?></option>
+                                            <?php endif; ?>
+                                        </select>
+                                        <p class="description"><?php esc_html_e( 'Start typing to search WooCommerce products.', 'bwk-accounting-lite' ); ?></p>
+                                    </div>
+                                </div>
+                            </td>
+                            <td><input type="number" step="0.01" name="qty[]" value="<?php echo esc_attr( $it->qty ); ?>" class="bwk-qty" /></td>
+                            <td><input type="number" step="0.01" name="unit_price[]" value="<?php echo esc_attr( $it->unit_price ); ?>" class="bwk-price" /></td>
+                            <td class="bwk-line-total"><?php echo esc_html( $it->line_total ); ?></td>
+                            <td><button type="button" class="button bwk-remove">&times;</button></td>
+                        </tr>
+                        <?php
                     }
                 }
                 ?>

--- a/bwk-accounting-lite/includes/class-admin-menu.php
+++ b/bwk-accounting-lite/includes/class-admin-menu.php
@@ -31,6 +31,25 @@ class BWK_Admin_Menu {
         }
         wp_enqueue_style( 'bwk-admin', BWK_AL_URL . 'admin/css/admin.css', array(), BWK_AL_VERSION );
         wp_enqueue_script( 'bwk-admin', BWK_AL_URL . 'admin/js/admin.js', array( 'jquery' ), BWK_AL_VERSION, true );
+        wp_localize_script(
+            'bwk-admin',
+            'bwkAdminData',
+            array(
+                'ajaxUrl'          => admin_url( 'admin-ajax.php' ),
+                'searchNonce'      => wp_create_nonce( 'bwk_search_products' ),
+                'productsEnabled'  => class_exists( 'WooCommerce' ),
+                'i18n'             => array(
+                    'useProductLabel'   => __( 'Use existing product', 'bwk-accounting-lite' ),
+                    'searchPlaceholder' => __( 'Search for a product…', 'bwk-accounting-lite' ),
+                    'searchHelp'        => __( 'Start typing to search WooCommerce products.', 'bwk-accounting-lite' ),
+                    'selectPrompt'      => __( 'Select a product', 'bwk-accounting-lite' ),
+                    'searching'         => __( 'Searching…', 'bwk-accounting-lite' ),
+                    'noResults'         => __( 'No products found.', 'bwk-accounting-lite' ),
+                    'error'             => __( 'Unable to load products.', 'bwk-accounting-lite' ),
+                    'noWooCommerce'     => __( 'WooCommerce must be active to search products.', 'bwk-accounting-lite' ),
+                ),
+            )
+        );
     }
     public static function admin_bar($wp_admin_bar) {
         if ( ! bwk_current_user_can() ) {

--- a/bwk-accounting-lite/includes/class-ajax.php
+++ b/bwk-accounting-lite/includes/class-ajax.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BWK_Ajax {
     public static function init() {
         add_action( 'wp_ajax_bwk_import_wc_orders', array( __CLASS__, 'import_wc_orders' ) );
+        add_action( 'wp_ajax_bwk_search_products', array( __CLASS__, 'search_products' ) );
     }
 
     public static function import_wc_orders() {
@@ -19,5 +20,70 @@ class BWK_Ajax {
         check_ajax_referer( 'bwk_import_wc_orders' );
         // Stub - actual import would run in batches.
         wp_send_json_success( array( 'done' => true ) );
+    }
+
+    public static function search_products() {
+        if ( ! bwk_current_user_can() ) {
+            wp_send_json_error( array( 'message' => __( 'Access denied.', 'bwk-accounting-lite' ) ) );
+        }
+
+        check_ajax_referer( 'bwk_search_products', 'nonce' );
+
+        if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'wc_get_products' ) ) {
+            wp_send_json_error( array( 'message' => __( 'WooCommerce is not active.', 'bwk-accounting-lite' ) ) );
+        }
+
+        $term = isset( $_REQUEST['term'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['term'] ) ) : '';
+        if ( strlen( $term ) < 2 ) {
+            wp_send_json_success( array( 'items' => array() ) );
+        }
+
+        $args = array(
+            'status'  => array( 'publish' ),
+            'limit'   => 20,
+            'orderby' => 'title',
+            'order'   => 'ASC',
+            'return'  => 'objects',
+        );
+
+        $products = wc_get_products( array_merge( $args, array(
+            'search' => '*' . $term . '*',
+        ) ) );
+
+        $sku_matches = wc_get_products( array_merge( $args, array(
+            'sku' => $term,
+        ) ) );
+
+        if ( $sku_matches ) {
+            $products = array_merge( $products, $sku_matches );
+        }
+
+        $items    = array();
+        $seen_ids = array();
+
+        foreach ( $products as $product ) {
+            if ( ! $product instanceof WC_Product ) {
+                continue;
+            }
+
+            $product_id = $product->get_id();
+            if ( isset( $seen_ids[ $product_id ] ) ) {
+                continue;
+            }
+
+            $price = function_exists( 'wc_get_price_to_display' ) ? wc_get_price_to_display( $product ) : $product->get_price();
+            $price = is_numeric( $price ) ? (float) $price : 0.0;
+
+            $items[] = array(
+                'id'    => $product_id,
+                'name'  => $product->get_name(),
+                'sku'   => $product->get_sku(),
+                'price' => $price,
+            );
+
+            $seen_ids[ $product_id ] = true;
+        }
+
+        wp_send_json_success( array( 'items' => $items ) );
     }
 }


### PR DESCRIPTION
## Summary
- add WooCommerce product selectors to invoice and quote line items so existing products can populate metadata
- extend admin JavaScript and styling to toggle the picker UI, request products, and fill item details
- expose a localized AJAX endpoint that searches WooCommerce products for authorized administrators

## Testing
- php -l bwk-accounting-lite/includes/class-ajax.php
- php -l bwk-accounting-lite/includes/class-admin-menu.php
- php -l bwk-accounting-lite/admin/views-invoice-edit.php
- php -l bwk-accounting-lite/admin/views-quote-edit.php

------
https://chatgpt.com/codex/tasks/task_e_68cee604a94c8330963fdaf823451305