### PR TITLE
Add interactive dashboard overview

### DIFF
--- a/bwk-accounting-lite/admin/css/admin.css
+++ b/bwk-accounting-lite/admin/css/admin.css
@@ -8,3 +8,75 @@
 #bwk-items-table .bwk-product-search,
 #bwk-items-table .bwk-product-select { width: 100%; }
 #bwk-items-table .bwk-product-search { margin-bottom: 4px; }
+
+/* Dashboard */
+.bwk-dashboard-wrap { max-width: 1120px; }
+.bwk-dashboard-kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin: 24px 0; }
+.bwk-dashboard-kpi { background: #fff; border: 1px solid #e5e7eb; border-radius: 14px; padding: 20px 22px; box-shadow: 0 1px 2px rgba(15,23,42,0.08); display: flex; flex-direction: column; gap: 6px; }
+.bwk-dashboard-kpi-label { font-size: 13px; letter-spacing: 0.04em; text-transform: uppercase; color: #6b7280; }
+.bwk-dashboard-kpi-value { font-size: 26px; font-weight: 600; color: #111827; }
+.bwk-dashboard-kpi-meta { font-size: 13px; color: #6b7280; }
+
+.bwk-dashboard-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin-bottom: 24px; }
+.bwk-dashboard-panel { background: #fff; border: 1px solid #e5e7eb; border-radius: 16px; padding: 20px 22px; box-shadow: 0 1px 2px rgba(15,23,42,0.08); display: flex; flex-direction: column; gap: 16px; min-height: 100%; }
+.bwk-dashboard-panel-header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.bwk-dashboard-panel-header h2 { margin: 0; font-size: 18px; font-weight: 600; color: #1f2937; }
+
+.bwk-dashboard-status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; }
+.bwk-dashboard-status-card { background: #f9fafb; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 6px; border: 1px solid #f3f4f6; }
+.bwk-dashboard-status-label { font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; }
+.bwk-dashboard-status-amount { font-size: 20px; font-weight: 600; color: #111827; }
+.bwk-dashboard-status-count { font-size: 13px; color: #6b7280; }
+
+.bwk-dashboard-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.bwk-dashboard-list-item { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; border-bottom: 1px solid #f3f4f6; padding-bottom: 10px; }
+.bwk-dashboard-list-item:last-child { border-bottom: 0; padding-bottom: 0; }
+.bwk-dashboard-list-label { font-weight: 600; color: #1f2937; }
+.bwk-dashboard-list-count { font-size: 13px; color: #6b7280; margin-left: auto; }
+.bwk-dashboard-list-amount { font-weight: 600; color: #1d4ed8; }
+
+.bwk-dashboard-chart { position: relative; width: 100%; }
+.bwk-dashboard-chart canvas { width: 100%; height: 260px; display: block; border-radius: 12px; background: linear-gradient(135deg, rgba(37,99,235,0.08), rgba(255,255,255,0)); }
+.bwk-dashboard-chart.is-empty canvas { opacity: 0.4; }
+.bwk-dashboard-chart-state { position: absolute; left: 16px; top: 16px; font-size: 13px; color: #6b7280; margin: 0; padding: 6px 10px; background: rgba(255,255,255,0.85); border-radius: 999px; box-shadow: 0 0 0 1px rgba(209,213,219,0.6); }
+.bwk-dashboard-chart-state[data-state="error"] { color: #b91c1c; background: rgba(254,226,226,0.92); box-shadow: 0 0 0 1px rgba(248,113,113,0.4); }
+
+.bwk-dashboard-legend-wrap { display: flex; flex-direction: column; gap: 10px; }
+.bwk-dashboard-legend { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.bwk-dashboard-legend-item { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; font-size: 13px; color: #1f2937; }
+.bwk-dashboard-legend-label { font-weight: 500; }
+.bwk-dashboard-legend-value { font-weight: 600; color: #1d4ed8; }
+.bwk-dashboard-legend-wrap .bwk-dashboard-empty-message { display: none; }
+.bwk-dashboard-legend-wrap.is-empty .bwk-dashboard-legend { display: none; }
+.bwk-dashboard-legend-wrap.is-empty .bwk-dashboard-empty-message { display: block; }
+
+.bwk-dashboard-activity { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 14px; }
+.bwk-dashboard-activity-item { display: flex; flex-direction: column; gap: 6px; padding-bottom: 12px; border-bottom: 1px solid #f3f4f6; }
+.bwk-dashboard-activity-item:last-child { border-bottom: 0; padding-bottom: 0; }
+.bwk-dashboard-activity-header { display: flex; align-items: center; gap: 10px; }
+.bwk-dashboard-activity-type { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #2563eb; background: rgba(37,99,235,0.12); padding: 4px 8px; border-radius: 999px; }
+.bwk-dashboard-activity-link { font-weight: 600; color: #111827; text-decoration: none; }
+.bwk-dashboard-activity-link:hover { color: #2563eb; }
+.bwk-dashboard-activity-status { margin-left: auto; font-size: 12px; font-weight: 600; text-transform: capitalize; padding: 4px 10px; border-radius: 999px; background: #eef2ff; color: #3730a3; }
+.bwk-dashboard-activity-status.status-paid, .bwk-dashboard-status-card.status-paid { background: #dcfce7; color: #15803d; }
+.bwk-dashboard-activity-status.status-sent { background: #e0f2fe; color: #0369a1; }
+.bwk-dashboard-activity-status.status-draft { background: #f3f4f6; color: #374151; }
+.bwk-dashboard-activity-status.status-partial { background: #fef9c3; color: #b45309; }
+.bwk-dashboard-activity-status.status-void { background: #fee2e2; color: #b91c1c; }
+.bwk-dashboard-activity-status.status-accepted { background: #dcfce7; color: #15803d; }
+.bwk-dashboard-activity-status.status-declined { background: #fee2e2; color: #b91c1c; }
+.bwk-dashboard-activity-status.status-sale { background: #e0f2fe; color: #0c4a6e; }
+.bwk-dashboard-activity-status.status-zakat { background: #fef3c7; color: #b45309; }
+
+.bwk-dashboard-activity-meta { display: flex; align-items: center; gap: 12px; font-size: 13px; color: #6b7280; }
+.bwk-dashboard-activity-amount { font-weight: 600; color: #111827; }
+.bwk-dashboard-activity-time { font-style: normal; }
+
+.bwk-dashboard-empty-message { font-size: 13px; color: #6b7280; margin: 0; }
+
+@media (max-width: 782px) {
+    .bwk-dashboard-kpi { padding: 18px; }
+    .bwk-dashboard-panel { padding: 18px; }
+    .bwk-dashboard-panel-header h2 { font-size: 17px; }
+    .bwk-dashboard-chart canvas { height: 220px; }
+}

--- a/bwk-accounting-lite/admin/js/dashboard.js
+++ b/bwk-accounting-lite/admin/js/dashboard.js
@@ -1,0 +1,254 @@
+(function(){
+    'use strict';
+
+    function onReady(callback) {
+        if ( document.readyState !== 'loading' ) {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    function setState(text, state) {
+        var el = document.getElementById('bwk-dashboard-chart-state');
+        if ( ! el ) {
+            return;
+        }
+        el.textContent = text || '';
+        el.dataset.state = state || '';
+        el.style.display = text ? 'block' : 'none';
+    }
+
+    function fetchChart() {
+        var settings = window.bwkDashboardData || {};
+        var ajaxUrl = settings.ajaxUrl;
+        var nonce = settings.chartNonce;
+        var i18n = settings.i18n || {};
+        var canvas = document.getElementById('bwk-dashboard-chart');
+        if ( ! ajaxUrl || ! nonce || ! canvas ) {
+            return;
+        }
+
+        setState(i18n.loading || 'Loading…', 'loading');
+
+        var params = new URLSearchParams();
+        params.append('action', 'bwk_dashboard_chart');
+        params.append('nonce', nonce);
+
+        fetch(ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+            body: params.toString()
+        })
+        .then(function(response){ return response.json(); })
+        .then(function(payload){
+            if ( ! payload || ! payload.success || ! payload.data ) {
+                throw new Error('Invalid payload');
+            }
+            var rendered = renderChart(canvas, payload.data);
+            updateLegend(payload.data);
+            if ( rendered ) {
+                setState('', '');
+            } else {
+                setState(i18n.empty || 'Not enough data yet.', 'empty');
+            }
+        })
+        .catch(function(){
+            setState(i18n.error || 'Unable to load chart data.', 'error');
+        });
+    }
+
+    function renderChart(canvas, payload) {
+        var wrapper = canvas && canvas.parentNode ? canvas.parentNode : null;
+        var values = payload && payload.values ? payload.values : [];
+        var labels = payload && payload.labels ? payload.labels : [];
+        if ( ! canvas ) {
+            return false;
+        }
+        if ( ! values.length || ! labels.length ) {
+            if ( wrapper ) {
+                wrapper.classList.add('is-empty');
+            }
+            return false;
+        }
+        if ( wrapper ) {
+            wrapper.classList.remove('is-empty');
+        }
+
+        var dpr = window.devicePixelRatio || 1;
+        var width = canvas.clientWidth * dpr;
+        var height = canvas.clientHeight * dpr;
+        if ( ! width || ! height ) {
+            width = 640 * dpr;
+            height = 320 * dpr;
+        }
+        canvas.width = width;
+        canvas.height = height;
+
+        var ctx = canvas.getContext('2d');
+        ctx.clearRect(0, 0, width, height);
+
+        var padding = 32 * dpr;
+        var plotWidth = width - padding * 2;
+        var plotHeight = height - padding * 2;
+        if ( plotWidth <= 0 || plotHeight <= 0 ) {
+            return;
+        }
+
+        var maxValue = values.reduce(function(max, value){
+            var numeric = parseFloat(value);
+            if ( isNaN(numeric) ) {
+                numeric = 0;
+            }
+            return numeric > max ? numeric : max;
+        }, 0);
+        if ( maxValue <= 0 ) {
+            maxValue = 1;
+        }
+
+        ctx.lineJoin = 'round';
+        ctx.lineCap = 'round';
+
+        // Axes
+        ctx.strokeStyle = '#e5e7eb';
+        ctx.lineWidth = 1 * dpr;
+        ctx.beginPath();
+        ctx.moveTo(padding, padding);
+        ctx.lineTo(padding, padding + plotHeight);
+        ctx.lineTo(padding + plotWidth, padding + plotHeight);
+        ctx.stroke();
+
+        // Grid lines
+        ctx.strokeStyle = '#f3f4f6';
+        ctx.lineWidth = 1 * dpr;
+        var gridSteps = 3;
+        for ( var i = 1; i <= gridSteps; i++ ) {
+            var y = padding + plotHeight - ( plotHeight * i / ( gridSteps + 1 ) );
+            ctx.beginPath();
+            ctx.moveTo(padding, y);
+            ctx.lineTo(padding + plotWidth, y);
+            ctx.stroke();
+        }
+
+        // Area fill
+        var gradient = ctx.createLinearGradient(0, padding, 0, padding + plotHeight);
+        gradient.addColorStop(0, 'rgba(37, 99, 235, 0.2)');
+        gradient.addColorStop(1, 'rgba(37, 99, 235, 0)');
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        values.forEach(function(value, index){
+            var numeric = parseFloat(value);
+            if ( isNaN(numeric) ) {
+                numeric = 0;
+            }
+            var x = padding;
+            if ( values.length > 1 ) {
+                x += plotWidth * ( index / ( values.length - 1 ) );
+            }
+            var y = padding + plotHeight - ( plotHeight * ( numeric / maxValue ) );
+            if ( index === 0 ) {
+                ctx.moveTo(x, y);
+            } else {
+                ctx.lineTo(x, y);
+            }
+        });
+        ctx.lineTo(padding + plotWidth, padding + plotHeight);
+        ctx.lineTo(padding, padding + plotHeight);
+        ctx.closePath();
+        ctx.fill();
+
+        // Line stroke
+        ctx.strokeStyle = '#2563eb';
+        ctx.lineWidth = 2 * dpr;
+        ctx.beginPath();
+        values.forEach(function(value, index){
+            var numeric = parseFloat(value);
+            if ( isNaN(numeric) ) {
+                numeric = 0;
+            }
+            var x = padding;
+            if ( values.length > 1 ) {
+                x += plotWidth * ( index / ( values.length - 1 ) );
+            }
+            var y = padding + plotHeight - ( plotHeight * ( numeric / maxValue ) );
+            if ( index === 0 ) {
+                ctx.moveTo(x, y);
+            } else {
+                ctx.lineTo(x, y);
+            }
+        });
+        ctx.stroke();
+
+        // Points
+        ctx.fillStyle = '#1d4ed8';
+        values.forEach(function(value, index){
+            var numeric = parseFloat(value);
+            if ( isNaN(numeric) ) {
+                numeric = 0;
+            }
+            var x = padding;
+            if ( values.length > 1 ) {
+                x += plotWidth * ( index / ( values.length - 1 ) );
+            }
+            var y = padding + plotHeight - ( plotHeight * ( numeric / maxValue ) );
+            ctx.beginPath();
+            ctx.arc(x, y, 3 * dpr, 0, Math.PI * 2, true);
+            ctx.fill();
+        });
+
+        return true;
+    }
+
+    function updateLegend(payload) {
+        var list = document.getElementById('bwk-dashboard-chart-legend');
+        var wrapper = list && list.parentNode ? list.parentNode : null;
+        if ( ! list ) {
+            return;
+        }
+        while ( list.firstChild ) {
+            list.removeChild(list.firstChild);
+        }
+
+        var labels = payload && payload.labels ? payload.labels : [];
+        var values = payload && payload.values ? payload.values : [];
+        var currency = payload && payload.currency ? payload.currency : '';
+
+        if ( ! labels.length || ! values.length ) {
+            if ( wrapper ) {
+                wrapper.classList.add('is-empty');
+            }
+            return;
+        }
+
+        if ( wrapper ) {
+            wrapper.classList.remove('is-empty');
+        }
+
+        labels.forEach(function(label, index){
+            var value = values[index];
+            var item = document.createElement('li');
+            item.className = 'bwk-dashboard-legend-item';
+
+            var labelSpan = document.createElement('span');
+            labelSpan.className = 'bwk-dashboard-legend-label';
+            labelSpan.textContent = label;
+
+            var valueSpan = document.createElement('span');
+            valueSpan.className = 'bwk-dashboard-legend-value';
+            var numeric = parseFloat(value);
+            if ( isNaN(numeric) ) {
+                valueSpan.textContent = value;
+            } else {
+                var formatted = numeric.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+                valueSpan.textContent = ( currency ? currency + ' ' : '' ) + formatted;
+            }
+
+            item.appendChild(labelSpan);
+            item.appendChild(valueSpan);
+            list.appendChild(item);
+        });
+    }
+
+    onReady(fetchChart);
+})();

--- a/bwk-accounting-lite/admin/partials/topbar-shortcuts.php
+++ b/bwk-accounting-lite/admin/partials/topbar-shortcuts.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $wp_admin_bar->add_node( array(
     'id'    => 'bwk-accounting',
     'title' => 'BWK Accounting',
-    'href'  => admin_url( 'admin.php?page=bwk-accounting' ),
+    'href'  => admin_url( 'admin.php?page=bwk-dashboard' ),
 ) );
 $wp_admin_bar->add_node( array(
     'id'     => 'bwk-accounting-invoices',

--- a/bwk-accounting-lite/admin/views-dashboard.php
+++ b/bwk-accounting-lite/admin/views-dashboard.php
@@ -1,0 +1,162 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$primary_currency = isset( $primary_currency ) && $primary_currency ? $primary_currency : 'USD';
+$currency_prefix  = $primary_currency ? $primary_currency . ' ' : '';
+$invoice_summary  = isset( $invoice_summary ) && is_array( $invoice_summary ) ? $invoice_summary : array();
+$invoice_total    = isset( $invoice_summary['amount'] ) ? (float) $invoice_summary['amount'] : 0.0;
+$invoice_count    = isset( $invoice_summary['count'] ) ? (int) $invoice_summary['count'] : 0;
+$invoice_paid     = isset( $invoice_summary['paid'] ) ? (float) $invoice_summary['paid'] : 0.0;
+$invoice_due      = isset( $invoice_summary['outstanding'] ) ? (float) $invoice_summary['outstanding'] : 0.0;
+$invoice_status_totals = isset( $invoice_status_totals ) && is_array( $invoice_status_totals ) ? $invoice_status_totals : array();
+$quote_status_totals   = isset( $quote_status_totals ) && is_array( $quote_status_totals ) ? $quote_status_totals : array();
+$recent_activity       = isset( $recent_activity ) && is_array( $recent_activity ) ? $recent_activity : array();
+?>
+<div class="wrap bwk-dashboard-wrap">
+    <h1><?php esc_html_e( 'Accounting Dashboard', 'bwk-accounting-lite' ); ?></h1>
+
+    <div class="bwk-dashboard-kpis">
+        <div class="bwk-dashboard-kpi">
+            <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Total Invoiced', 'bwk-accounting-lite' ); ?></span>
+            <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $invoice_total, 2 ) ); ?></span>
+            <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( sprintf( _n( '%s invoice recorded', '%s invoices recorded', $invoice_count, 'bwk-accounting-lite' ), number_format_i18n( $invoice_count ) ) ); ?></span>
+        </div>
+        <div class="bwk-dashboard-kpi">
+            <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Paid to Date', 'bwk-accounting-lite' ); ?></span>
+            <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $invoice_paid, 2 ) ); ?></span>
+            <?php
+            $paid_ratio = $invoice_total > 0 ? round( ( $invoice_paid / $invoice_total ) * 100 ) : 0;
+            ?>
+            <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( sprintf( __( '%s%% of invoiced total', 'bwk-accounting-lite' ), number_format_i18n( $paid_ratio ) ) ); ?></span>
+        </div>
+        <div class="bwk-dashboard-kpi">
+            <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Outstanding Balance', 'bwk-accounting-lite' ); ?></span>
+            <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $invoice_due, 2 ) ); ?></span>
+            <?php
+            $due_ratio = $invoice_total > 0 ? round( ( $invoice_due / $invoice_total ) * 100 ) : 0;
+            ?>
+            <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( sprintf( __( '%s%% awaiting payment', 'bwk-accounting-lite' ), number_format_i18n( $due_ratio ) ) ); ?></span>
+        </div>
+    </div>
+
+    <div class="bwk-dashboard-grid">
+        <section class="bwk-dashboard-panel">
+            <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Invoice Status Overview', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <div class="bwk-dashboard-status-grid">
+                <?php foreach ( $invoice_status_totals as $status => $row ) :
+                    $fallback_label = ucwords( str_replace( array( '-', '_' ), ' ', (string) $status ) );
+                    $label = isset( $row['label'] ) ? $row['label'] : $fallback_label;
+                    $count = isset( $row['count'] ) ? (int) $row['count'] : 0;
+                    $total = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
+                    $status_class = $status ? ' status-' . sanitize_html_class( $status ) : '';
+                    ?>
+                    <div class="bwk-dashboard-status-card<?php echo esc_attr( $status_class ); ?>">
+                        <span class="bwk-dashboard-status-label"><?php echo esc_html( $label ); ?></span>
+                        <span class="bwk-dashboard-status-amount"><?php echo esc_html( $currency_prefix . number_format_i18n( $total, 2 ) ); ?></span>
+                        <span class="bwk-dashboard-status-count"><?php echo esc_html( sprintf( _n( '%s invoice', '%s invoices', $count, 'bwk-accounting-lite' ), number_format_i18n( $count ) ) ); ?></span>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <section class="bwk-dashboard-panel">
+            <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Quote Pipeline', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <ul class="bwk-dashboard-list">
+                <?php
+                $has_quote_activity = false;
+                foreach ( $quote_status_totals as $status => $row ) :
+                    $fallback_label = ucwords( str_replace( array( '-', '_' ), ' ', (string) $status ) );
+                    $label = isset( $row['label'] ) ? $row['label'] : $fallback_label;
+                    $count = isset( $row['count'] ) ? (int) $row['count'] : 0;
+                    $total = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
+                    if ( $count > 0 || $total > 0 ) {
+                        $has_quote_activity = true;
+                    }
+                    ?>
+                    <li class="bwk-dashboard-list-item">
+                        <span class="bwk-dashboard-list-label"><?php echo esc_html( $label ); ?></span>
+                        <span class="bwk-dashboard-list-count"><?php echo esc_html( sprintf( _n( '%s quote', '%s quotes', $count, 'bwk-accounting-lite' ), number_format_i18n( $count ) ) ); ?></span>
+                        <span class="bwk-dashboard-list-amount"><?php echo esc_html( $currency_prefix . number_format_i18n( $total, 2 ) ); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+            <?php if ( ! $has_quote_activity ) : ?>
+                <p class="bwk-dashboard-empty-message"><?php esc_html_e( 'No quotes recorded yet. Create one to start tracking your pipeline.', 'bwk-accounting-lite' ); ?></p>
+            <?php endif; ?>
+        </section>
+    </div>
+
+    <div class="bwk-dashboard-grid">
+        <section class="bwk-dashboard-panel bwk-dashboard-panel-chart">
+            <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Revenue Trend', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <div class="bwk-dashboard-chart">
+                <canvas id="bwk-dashboard-chart"></canvas>
+                <p id="bwk-dashboard-chart-state" class="bwk-dashboard-chart-state"><?php esc_html_e( 'Loading…', 'bwk-accounting-lite' ); ?></p>
+            </div>
+            <div class="bwk-dashboard-legend-wrap is-empty">
+                <ul id="bwk-dashboard-chart-legend" class="bwk-dashboard-legend"></ul>
+                <p class="bwk-dashboard-empty-message"><?php esc_html_e( 'Chart data will appear once invoices are marked as paid.', 'bwk-accounting-lite' ); ?></p>
+            </div>
+        </section>
+        <section class="bwk-dashboard-panel">
+            <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Recent Activity', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <?php if ( $recent_activity ) : ?>
+                <ul class="bwk-dashboard-activity">
+                    <?php foreach ( $recent_activity as $activity ) :
+                        $type_label   = isset( $activity['type_label'] ) ? $activity['type_label'] : '';
+                        $title        = isset( $activity['title'] ) ? $activity['title'] : '';
+                        $url          = isset( $activity['url'] ) ? $activity['url'] : '';
+                        $status       = isset( $activity['status'] ) ? $activity['status'] : '';
+                        $status_label = isset( $activity['status_label'] ) ? $activity['status_label'] : '';
+                        $status_class = $status ? ' status-' . sanitize_html_class( $status ) : '';
+                        $amount_value = isset( $activity['total'] ) ? (float) $activity['total'] : null;
+                        $activity_currency = isset( $activity['currency'] ) && $activity['currency'] ? $activity['currency'] : $primary_currency;
+                        $amount_display = null === $amount_value ? '' : $activity_currency . ' ' . number_format_i18n( $amount_value, 2 );
+                        $timestamp  = isset( $activity['timestamp'] ) ? (int) $activity['timestamp'] : 0;
+                        $time_phrase = '';
+                        $datetime_attr = '';
+                        if ( $timestamp ) {
+                            $time_phrase  = human_time_diff( $timestamp, current_time( 'timestamp' ) );
+                            $datetime_attr = wp_date( 'c', $timestamp );
+                        }
+                        ?>
+                        <li class="bwk-dashboard-activity-item">
+                            <div class="bwk-dashboard-activity-header">
+                                <?php if ( $type_label ) : ?>
+                                    <span class="bwk-dashboard-activity-type"><?php echo esc_html( $type_label ); ?></span>
+                                <?php endif; ?>
+                                <?php if ( $url ) : ?>
+                                    <a class="bwk-dashboard-activity-link" href="<?php echo esc_url( $url ); ?>"><?php echo esc_html( $title ); ?></a>
+                                <?php else : ?>
+                                    <span class="bwk-dashboard-activity-link"><?php echo esc_html( $title ); ?></span>
+                                <?php endif; ?>
+                                <?php if ( $status_label ) : ?>
+                                    <span class="bwk-dashboard-activity-status<?php echo esc_attr( $status_class ); ?>"><?php echo esc_html( $status_label ); ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <div class="bwk-dashboard-activity-meta">
+                                <?php if ( '' !== $amount_display ) : ?>
+                                    <span class="bwk-dashboard-activity-amount"><?php echo esc_html( $amount_display ); ?></span>
+                                <?php endif; ?>
+                                <?php if ( $time_phrase ) : ?>
+                                    <time class="bwk-dashboard-activity-time" datetime="<?php echo esc_attr( $datetime_attr ); ?>"><?php echo esc_html( sprintf( __( '%s ago', 'bwk-accounting-lite' ), $time_phrase ) ); ?></time>
+                                <?php endif; ?>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else : ?>
+                <p class="bwk-dashboard-empty-message"><?php esc_html_e( 'Your latest invoices, quotes, and ledger updates will appear here.', 'bwk-accounting-lite' ); ?></p>
+            <?php endif; ?>
+        </section>
+    </div>
+</div>

--- a/bwk-accounting-lite/bwk-accounting-lite.php
+++ b/bwk-accounting-lite/bwk-accounting-lite.php
@@ -36,6 +36,7 @@ register_uninstall_hook( __FILE__, array( 'BWK_Uninstaller', 'uninstall' ) );
 function bwk_accounting_lite_init() {
     BWK_Activator::upgrade();
     BWK_Settings::init();
+    BWK_Dashboard::init();
     BWK_Admin_Menu::init();
     BWK_Invoices::init();
     BWK_Quotes_Table::init();

--- a/bwk-accounting-lite/includes/class-admin-menu.php
+++ b/bwk-accounting-lite/includes/class-admin-menu.php
@@ -16,13 +16,14 @@ class BWK_Admin_Menu {
 
     public static function register_menu() {
         $cap = 'manage_options';
-        add_menu_page( __( 'BWK Accounting', 'bwk-accounting-lite' ), __( 'BWK Accounting', 'bwk-accounting-lite' ), $cap, 'bwk-accounting', array( 'BWK_Invoices', 'render_list_page' ), 'dashicons-media-spreadsheet', 56 );
-        add_submenu_page( 'bwk-accounting', __( 'Invoices', 'bwk-accounting-lite' ), __( 'Invoices', 'bwk-accounting-lite' ), $cap, 'bwk-accounting', array( 'BWK_Invoices', 'render_list_page' ) );
-        add_submenu_page( 'bwk-accounting', __( 'Add New Invoice', 'bwk-accounting-lite' ), __( 'Add New', 'bwk-accounting-lite' ), $cap, 'bwk-invoice-add', array( 'BWK_Invoices', 'render_edit_page' ) );
-        add_submenu_page( 'bwk-accounting', __( 'Quotes', 'bwk-accounting-lite' ), __( 'Quotes', 'bwk-accounting-lite' ), $cap, 'bwk-quotes', array( 'BWK_Quotes_Table', 'render_list_page' ) );
-        add_submenu_page( 'bwk-accounting', __( 'Add New Quote', 'bwk-accounting-lite' ), __( 'Add Quote', 'bwk-accounting-lite' ), $cap, 'bwk-quote-add', array( 'BWK_Quotes_Table', 'render_edit_page' ) );
-        add_submenu_page( 'bwk-accounting', __( 'Ledger', 'bwk-accounting-lite' ), __( 'Ledger', 'bwk-accounting-lite' ), $cap, 'bwk-ledger', array( 'BWK_Ledger', 'render_list_page' ) );
-        add_submenu_page( 'bwk-accounting', __( 'Settings', 'bwk-accounting-lite' ), __( 'Settings', 'bwk-accounting-lite' ), $cap, 'bwk-settings', array( 'BWK_Settings', 'render_settings_page' ) );
+        add_menu_page( __( 'BWK Dashboard', 'bwk-accounting-lite' ), __( 'BWK Accounting', 'bwk-accounting-lite' ), $cap, 'bwk-dashboard', array( 'BWK_Dashboard', 'render_page' ), 'dashicons-chart-area', 56 );
+        add_submenu_page( 'bwk-dashboard', __( 'Dashboard', 'bwk-accounting-lite' ), __( 'Dashboard', 'bwk-accounting-lite' ), $cap, 'bwk-dashboard', array( 'BWK_Dashboard', 'render_page' ) );
+        add_submenu_page( 'bwk-dashboard', __( 'Invoices', 'bwk-accounting-lite' ), __( 'Invoices', 'bwk-accounting-lite' ), $cap, 'bwk-accounting', array( 'BWK_Invoices', 'render_list_page' ) );
+        add_submenu_page( 'bwk-dashboard', __( 'Add New Invoice', 'bwk-accounting-lite' ), __( 'Add New', 'bwk-accounting-lite' ), $cap, 'bwk-invoice-add', array( 'BWK_Invoices', 'render_edit_page' ) );
+        add_submenu_page( 'bwk-dashboard', __( 'Quotes', 'bwk-accounting-lite' ), __( 'Quotes', 'bwk-accounting-lite' ), $cap, 'bwk-quotes', array( 'BWK_Quotes_Table', 'render_list_page' ) );
+        add_submenu_page( 'bwk-dashboard', __( 'Add New Quote', 'bwk-accounting-lite' ), __( 'Add Quote', 'bwk-accounting-lite' ), $cap, 'bwk-quote-add', array( 'BWK_Quotes_Table', 'render_edit_page' ) );
+        add_submenu_page( 'bwk-dashboard', __( 'Ledger', 'bwk-accounting-lite' ), __( 'Ledger', 'bwk-accounting-lite' ), $cap, 'bwk-ledger', array( 'BWK_Ledger', 'render_list_page' ) );
+        add_submenu_page( 'bwk-dashboard', __( 'Settings', 'bwk-accounting-lite' ), __( 'Settings', 'bwk-accounting-lite' ), $cap, 'bwk-settings', array( 'BWK_Settings', 'render_settings_page' ) );
     }
 
     public static function enqueue_assets( $hook ) {

--- a/bwk-accounting-lite/includes/class-dashboard.php
+++ b/bwk-accounting-lite/includes/class-dashboard.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * Dashboard metrics and admin page controller.
+ *
+ * @author Wan Mohd Aiman Binawebpro.com
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class BWK_Dashboard {
+    /**
+     * Hook registrations.
+     */
+    public static function init() {
+        add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+        add_action( 'wp_ajax_bwk_dashboard_chart', array( __CLASS__, 'ajax_chart_data' ) );
+    }
+
+    /**
+     * Render the dashboard page.
+     */
+    public static function render_page() {
+        if ( ! bwk_current_user_can() ) {
+            return;
+        }
+
+        $invoice_status_totals = self::get_invoice_status_totals();
+        $quote_status_totals   = self::get_quote_status_totals();
+        $recent_activity       = self::get_recent_activity();
+        $invoice_summary       = self::summarize_invoice_totals( $invoice_status_totals );
+        $primary_currency      = self::get_primary_currency();
+
+        include BWK_AL_PATH . 'admin/views-dashboard.php';
+    }
+
+    /**
+     * Enqueue dashboard-specific assets.
+     *
+     * @param string $hook Current admin hook suffix.
+     */
+    public static function enqueue_assets( $hook ) {
+        if ( 'toplevel_page_bwk-dashboard' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'bwk-dashboard',
+            BWK_AL_URL . 'admin/js/dashboard.js',
+            array(),
+            BWK_AL_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'bwk-dashboard',
+            'bwkDashboardData',
+            array(
+                'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+                'chartNonce' => wp_create_nonce( 'bwk_dashboard_chart' ),
+                'i18n'       => array(
+                    'loading' => __( 'Loading…', 'bwk-accounting-lite' ),
+                    'empty'   => __( 'Not enough data yet.', 'bwk-accounting-lite' ),
+                    'error'   => __( 'Unable to load chart data.', 'bwk-accounting-lite' ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * AJAX handler for revenue chart data.
+     */
+    public static function ajax_chart_data() {
+        if ( ! bwk_current_user_can() ) {
+            wp_send_json_error( array( 'message' => __( 'Access denied.', 'bwk-accounting-lite' ) ), 403 );
+        }
+
+        check_ajax_referer( 'bwk_dashboard_chart', 'nonce' );
+
+        $months = isset( $_REQUEST['months'] ) ? absint( $_REQUEST['months'] ) : 6;
+        if ( $months < 3 ) {
+            $months = 3;
+        }
+        if ( $months > 24 ) {
+            $months = 24;
+        }
+
+        $series = self::get_revenue_series( $months );
+        wp_send_json_success( $series );
+    }
+
+    /**
+     * Retrieve invoice totals grouped by status.
+     *
+     * @return array
+     */
+    protected static function get_invoice_status_totals() {
+        global $wpdb;
+        $table  = bwk_table_invoices();
+        $rows   = $wpdb->get_results( "SELECT status, COUNT(*) AS count, SUM(grand_total) AS total FROM $table GROUP BY status", ARRAY_A );
+        $totals = array();
+
+        if ( $rows ) {
+            foreach ( $rows as $row ) {
+                $status = isset( $row['status'] ) ? sanitize_key( $row['status'] ) : 'unknown';
+                $totals[ $status ] = array(
+                    'status' => $status,
+                    'label'  => self::format_status_label( $status ),
+                    'count'  => isset( $row['count'] ) ? absint( $row['count'] ) : 0,
+                    'total'  => isset( $row['total'] ) ? (float) $row['total'] : 0.0,
+                );
+            }
+        }
+
+        $defaults = array( 'paid', 'sent', 'partial', 'draft', 'void' );
+        return self::order_status_data( $totals, $defaults );
+    }
+
+    /**
+     * Retrieve quote totals grouped by status.
+     *
+     * @return array
+     */
+    protected static function get_quote_status_totals() {
+        global $wpdb;
+        $table  = bwk_table_quotes();
+        $rows   = $wpdb->get_results( "SELECT status, COUNT(*) AS count, SUM(grand_total) AS total FROM $table GROUP BY status", ARRAY_A );
+        $totals = array();
+
+        if ( $rows ) {
+            foreach ( $rows as $row ) {
+                $status = isset( $row['status'] ) ? sanitize_key( $row['status'] ) : 'unknown';
+                $totals[ $status ] = array(
+                    'status' => $status,
+                    'label'  => self::format_status_label( $status ),
+                    'count'  => isset( $row['count'] ) ? absint( $row['count'] ) : 0,
+                    'total'  => isset( $row['total'] ) ? (float) $row['total'] : 0.0,
+                );
+            }
+        }
+
+        $defaults = array( 'accepted', 'sent', 'draft', 'declined' );
+        return self::order_status_data( $totals, $defaults );
+    }
+
+    /**
+     * Build a combined recent activity feed.
+     *
+     * @param int $limit Number of records to return.
+     *
+     * @return array
+     */
+    protected static function get_recent_activity( $limit = 6 ) {
+        global $wpdb;
+        $limit        = max( 1, absint( $limit ) );
+        $fetch_amount = max( 1, $limit * 2 );
+        $items        = array();
+
+        $invoice_query = $wpdb->prepare(
+            'SELECT id, number, status, grand_total, currency, updated_at FROM ' . bwk_table_invoices() . ' ORDER BY updated_at DESC LIMIT %d',
+            $fetch_amount
+        );
+        $invoice_rows  = $wpdb->get_results( $invoice_query, ARRAY_A );
+
+        if ( $invoice_rows ) {
+            foreach ( $invoice_rows as $row ) {
+                $timestamp = isset( $row['updated_at'] ) ? strtotime( $row['updated_at'] ) : 0;
+                $items[]   = array(
+                    'type'         => 'invoice',
+                    'type_label'   => __( 'Invoice', 'bwk-accounting-lite' ),
+                    'title'        => isset( $row['number'] ) && $row['number'] ? sprintf( __( 'Invoice %s', 'bwk-accounting-lite' ), $row['number'] ) : __( 'Invoice', 'bwk-accounting-lite' ),
+                    'status'       => isset( $row['status'] ) ? sanitize_key( $row['status'] ) : '',
+                    'status_label' => isset( $row['status'] ) ? self::format_status_label( $row['status'] ) : '',
+                    'total'        => isset( $row['grand_total'] ) ? (float) $row['grand_total'] : 0.0,
+                    'currency'     => isset( $row['currency'] ) ? self::normalize_currency( $row['currency'] ) : '',
+                    'timestamp'    => $timestamp ? $timestamp : 0,
+                    'url'          => admin_url( 'admin.php?page=bwk-invoice-add&id=' . absint( $row['id'] ) ),
+                );
+            }
+        }
+
+        $quote_query = $wpdb->prepare(
+            'SELECT id, number, status, grand_total, currency, updated_at FROM ' . bwk_table_quotes() . ' ORDER BY updated_at DESC LIMIT %d',
+            $fetch_amount
+        );
+        $quote_rows  = $wpdb->get_results( $quote_query, ARRAY_A );
+
+        if ( $quote_rows ) {
+            foreach ( $quote_rows as $row ) {
+                $timestamp = isset( $row['updated_at'] ) ? strtotime( $row['updated_at'] ) : 0;
+                $items[]   = array(
+                    'type'         => 'quote',
+                    'type_label'   => __( 'Quote', 'bwk-accounting-lite' ),
+                    'title'        => isset( $row['number'] ) && $row['number'] ? sprintf( __( 'Quote %s', 'bwk-accounting-lite' ), $row['number'] ) : __( 'Quote', 'bwk-accounting-lite' ),
+                    'status'       => isset( $row['status'] ) ? sanitize_key( $row['status'] ) : '',
+                    'status_label' => isset( $row['status'] ) ? self::format_status_label( $row['status'] ) : '',
+                    'total'        => isset( $row['grand_total'] ) ? (float) $row['grand_total'] : 0.0,
+                    'currency'     => isset( $row['currency'] ) ? self::normalize_currency( $row['currency'] ) : '',
+                    'timestamp'    => $timestamp ? $timestamp : 0,
+                    'url'          => admin_url( 'admin.php?page=bwk-quote-add&id=' . absint( $row['id'] ) ),
+                );
+            }
+        }
+
+        $ledger_query = $wpdb->prepare(
+            'SELECT id, txn_type, amount, currency, txn_date FROM ' . bwk_table_ledger() . ' ORDER BY txn_date DESC LIMIT %d',
+            $limit
+        );
+        $ledger_rows  = $wpdb->get_results( $ledger_query, ARRAY_A );
+
+        if ( $ledger_rows ) {
+            foreach ( $ledger_rows as $row ) {
+                $timestamp = isset( $row['txn_date'] ) ? strtotime( $row['txn_date'] ) : 0;
+                $items[]   = array(
+                    'type'         => 'ledger',
+                    'type_label'   => __( 'Ledger', 'bwk-accounting-lite' ),
+                    'title'        => isset( $row['txn_type'] ) ? self::format_status_label( $row['txn_type'] ) : __( 'Ledger entry', 'bwk-accounting-lite' ),
+                    'status'       => isset( $row['txn_type'] ) ? sanitize_key( $row['txn_type'] ) : '',
+                    'status_label' => isset( $row['txn_type'] ) ? self::format_status_label( $row['txn_type'] ) : '',
+                    'total'        => isset( $row['amount'] ) ? (float) $row['amount'] : 0.0,
+                    'currency'     => isset( $row['currency'] ) ? self::normalize_currency( $row['currency'] ) : '',
+                    'timestamp'    => $timestamp ? $timestamp : 0,
+                    'url'          => admin_url( 'admin.php?page=bwk-ledger' ),
+                );
+            }
+        }
+
+        if ( $items ) {
+            usort(
+                $items,
+                function ( $a, $b ) {
+                    $ta = isset( $a['timestamp'] ) ? (int) $a['timestamp'] : 0;
+                    $tb = isset( $b['timestamp'] ) ? (int) $b['timestamp'] : 0;
+
+                    if ( $ta === $tb ) {
+                        return 0;
+                    }
+
+                    return ( $ta > $tb ) ? -1 : 1;
+                }
+            );
+        }
+
+        return array_slice( $items, 0, $limit );
+    }
+
+    /**
+     * Summarise invoice totals for key metrics.
+     *
+     * @param array $status_totals Invoice totals by status.
+     *
+     * @return array
+     */
+    protected static function summarize_invoice_totals( $status_totals ) {
+        $summary = array(
+            'count'       => 0,
+            'amount'      => 0.0,
+            'paid'        => 0.0,
+            'outstanding' => 0.0,
+        );
+
+        if ( empty( $status_totals ) || ! is_array( $status_totals ) ) {
+            return $summary;
+        }
+
+        foreach ( $status_totals as $status => $row ) {
+            $count = isset( $row['count'] ) ? (int) $row['count'] : 0;
+            $total = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
+
+            $summary['count']  += $count;
+            $summary['amount'] += $total;
+
+            if ( in_array( $status, array( 'paid' ), true ) ) {
+                $summary['paid'] += $total;
+            } elseif ( in_array( $status, array( 'void', 'cancelled' ), true ) ) {
+                continue;
+            } else {
+                $summary['outstanding'] += $total;
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Create a human-friendly label for a status string.
+     *
+     * @param string $status Status value.
+     *
+     * @return string
+     */
+    protected static function format_status_label( $status ) {
+        $status = is_string( $status ) ? strtolower( $status ) : '';
+        $status = str_replace( array( '-', '_' ), ' ', $status );
+
+        return ucwords( trim( $status ) );
+    }
+
+    /**
+     * Normalise a currency code string.
+     *
+     * @param string $currency Raw currency value.
+     *
+     * @return string
+     */
+    protected static function normalize_currency( $currency ) {
+        if ( ! is_string( $currency ) ) {
+            return '';
+        }
+
+        $normalized = strtoupper( preg_replace( '/[^A-Z]/', '', $currency ) );
+
+        return $normalized;
+    }
+
+    /**
+     * Determine the primary currency to display within the dashboard.
+     *
+     * @return string
+     */
+    protected static function get_primary_currency() {
+        global $wpdb;
+
+        $currency = $wpdb->get_var( 'SELECT currency FROM ' . bwk_table_invoices() . ' ORDER BY updated_at DESC LIMIT 1' );
+
+        if ( ! $currency ) {
+            $currency = $wpdb->get_var( 'SELECT currency FROM ' . bwk_table_quotes() . ' ORDER BY updated_at DESC LIMIT 1' );
+        }
+
+        if ( ! $currency ) {
+            $currency = bwk_get_option( 'default_currency', 'USD' );
+        }
+
+        $currency = self::normalize_currency( $currency );
+
+        return $currency ? $currency : 'USD';
+    }
+
+    /**
+     * Retrieve the revenue series grouped by month.
+     *
+     * @param int $months Number of months to include.
+     *
+     * @return array
+     */
+    protected static function get_revenue_series( $months = 6 ) {
+        global $wpdb;
+
+        $months = max( 1, absint( $months ) );
+        $end    = current_time( 'timestamp' );
+        $start  = strtotime( '-' . ( $months - 1 ) . ' months', $end );
+        $start  = $start ? $start : $end;
+        $start_date = wp_date( 'Y-m-01 00:00:00', $start );
+
+        $statuses      = array( 'paid' );
+        $placeholders  = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+        $params        = array( $start_date );
+        $sql_condition = '';
+
+        if ( $statuses ) {
+            $sql_condition = ' AND status IN (' . $placeholders . ')';
+            $params        = array_merge( $params, $statuses );
+        }
+
+        $sql = 'SELECT DATE_FORMAT(created_at, "%%Y-%%m-01") AS period, SUM(grand_total) AS total FROM ' . bwk_table_invoices() . ' WHERE created_at >= %s' . $sql_condition . ' GROUP BY period ORDER BY period ASC';
+
+        $prepared = $wpdb->prepare( $sql, $params );
+        $rows     = $wpdb->get_results( $prepared, ARRAY_A );
+        $map      = array();
+
+        if ( $rows ) {
+            foreach ( $rows as $row ) {
+                if ( empty( $row['period'] ) ) {
+                    continue;
+                }
+                $key         = $row['period'];
+                $map[ $key ] = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
+            }
+        }
+
+        $labels = array();
+        $values = array();
+
+        for ( $i = $months - 1; $i >= 0; $i-- ) {
+            $month_ts  = strtotime( '-' . $i . ' months', $end );
+            $month_ts  = $month_ts ? $month_ts : $end;
+            $period    = wp_date( 'Y-m-01', $month_ts );
+            $labels[]  = wp_date( 'M Y', $month_ts );
+            $values[]  = isset( $map[ $period ] ) ? round( (float) $map[ $period ], 2 ) : 0.0;
+        }
+
+        return array(
+            'labels'   => $labels,
+            'values'   => $values,
+            'currency' => self::get_primary_currency(),
+        );
+    }
+
+    /**
+     * Ensure status arrays contain sensible ordering and defaults.
+     *
+     * @param array $data     Status data keyed by status.
+     * @param array $defaults Default order.
+     *
+     * @return array
+     */
+    protected static function order_status_data( $data, $defaults ) {
+        $ordered = array();
+
+        if ( ! is_array( $data ) ) {
+            $data = array();
+        }
+
+        if ( ! is_array( $defaults ) ) {
+            $defaults = array();
+        }
+
+        foreach ( $defaults as $status ) {
+            $key = sanitize_key( $status );
+            if ( isset( $data[ $key ] ) ) {
+                $ordered[ $key ] = $data[ $key ];
+                unset( $data[ $key ] );
+            } else {
+                $ordered[ $key ] = array(
+                    'status' => $key,
+                    'label'  => self::format_status_label( $key ),
+                    'count'  => 0,
+                    'total'  => 0.0,
+                );
+            }
+        }
+
+        foreach ( $data as $status => $row ) {
+            $ordered[ $status ] = $row;
+        }
+
+        return $ordered;
+    }
+}


### PR DESCRIPTION
## Summary
- add a BWK_Dashboard controller that aggregates invoice, quote, and ledger metrics while exposing an authenticated AJAX series endpoint
- wire the main admin menu to the dashboard, load tailored assets, and render a minimalist cards-and-chart layout for totals and pipeline data
- deliver a lightweight canvas-based revenue chart plus recent activity feed via new admin CSS/JS assets and view template

## Testing
- php -l bwk-accounting-lite/includes/class-dashboard.php
- php -l bwk-accounting-lite/admin/views-dashboard.php
- php -l bwk-accounting-lite/includes/class-admin-menu.php
- php -l bwk-accounting-lite/admin/partials/topbar-shortcuts.php

------
https://chatgpt.com/codex/tasks/task_e_68ceead7134c8330ae42f6175c244ab9