### PR TITLE
Enhance admin dashboard insights and layout

### DIFF
--- a/bwk-accounting-lite/admin/css/admin.css
+++ b/bwk-accounting-lite/admin/css/admin.css
@@ -10,52 +10,82 @@
 #bwk-items-table .bwk-product-search { margin-bottom: 4px; }
 
 /* Dashboard */
-.bwk-dashboard-wrap { max-width: 1120px; }
-.bwk-dashboard-kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin: 24px 0; }
-.bwk-dashboard-kpi { background: #fff; border: 1px solid #e5e7eb; border-radius: 14px; padding: 20px 22px; box-shadow: 0 1px 2px rgba(15,23,42,0.08); display: flex; flex-direction: column; gap: 6px; }
-.bwk-dashboard-kpi-label { font-size: 13px; letter-spacing: 0.04em; text-transform: uppercase; color: #6b7280; }
-.bwk-dashboard-kpi-value { font-size: 26px; font-weight: 600; color: #111827; }
-.bwk-dashboard-kpi-meta { font-size: 13px; color: #6b7280; }
+.bwk-dashboard-wrap { max-width: 1200px; }
+.bwk-dashboard-heading { display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px; }
+.bwk-dashboard-heading h1 { margin: 0; font-size: 28px; font-weight: 600; color: #0f172a; }
+.bwk-dashboard-subtitle { margin: 0; font-size: 15px; color: #64748b; max-width: 680px; }
 
-.bwk-dashboard-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin-bottom: 24px; }
-.bwk-dashboard-panel { background: #fff; border: 1px solid #e5e7eb; border-radius: 16px; padding: 20px 22px; box-shadow: 0 1px 2px rgba(15,23,42,0.08); display: flex; flex-direction: column; gap: 16px; min-height: 100%; }
+.bwk-dashboard-kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin: 24px 0 32px; }
+.bwk-dashboard-kpi { background: #fff; border: 1px solid #e2e8f0; border-radius: 16px; padding: 20px 22px; box-shadow: 0 8px 18px rgba(15,23,42,0.05); display: flex; flex-direction: column; gap: 6px; min-height: 132px; }
+.bwk-dashboard-kpi-label { font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: #94a3b8; }
+.bwk-dashboard-kpi-value { font-size: 28px; font-weight: 600; color: #0f172a; }
+.bwk-dashboard-kpi-meta { font-size: 13px; color: #64748b; }
+.bwk-dashboard-kpi--profit.is-positive .bwk-dashboard-kpi-value { color: #16a34a; }
+.bwk-dashboard-kpi--profit.is-negative .bwk-dashboard-kpi-value,
+.bwk-dashboard-kpi--profit.is-negative .bwk-dashboard-kpi-meta { color: #b91c1c; }
+.bwk-dashboard-kpi--accent { background: linear-gradient(135deg, rgba(191,219,254,0.35), rgba(255,255,255,0.9)); border-color: rgba(191,219,254,0.6); }
+.bwk-dashboard-kpi--accent .bwk-dashboard-kpi-value { color: #1d4ed8; }
+.bwk-dashboard-kpi--accent .bwk-dashboard-kpi-meta { color: #2563eb; }
+
+.bwk-dashboard-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin-bottom: 28px; align-items: stretch; }
+.bwk-dashboard-grid--feature { grid-template-columns: minmax(320px, 1.6fr) minmax(260px, 1fr); }
+
+.bwk-dashboard-panel { background: #fff; border: 1px solid #e2e8f0; border-radius: 18px; padding: 22px 24px; box-shadow: 0 18px 24px rgba(15,23,42,0.06); display: flex; flex-direction: column; gap: 16px; min-height: 100%; }
 .bwk-dashboard-panel-header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
-.bwk-dashboard-panel-header h2 { margin: 0; font-size: 18px; font-weight: 600; color: #1f2937; }
+.bwk-dashboard-panel-header h2 { margin: 0; font-size: 18px; font-weight: 600; color: #0f172a; }
 
-.bwk-dashboard-status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; }
-.bwk-dashboard-status-card { background: #f9fafb; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 6px; border: 1px solid #f3f4f6; }
-.bwk-dashboard-status-label { font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; }
-.bwk-dashboard-status-amount { font-size: 20px; font-weight: 600; color: #111827; }
-.bwk-dashboard-status-count { font-size: 13px; color: #6b7280; }
+.bwk-dashboard-status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 14px; }
+.bwk-dashboard-status-card { background: #f8fafc; border-radius: 14px; padding: 16px; display: flex; flex-direction: column; gap: 6px; border: 1px solid #e2e8f0; }
+.bwk-dashboard-status-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: #94a3b8; }
+.bwk-dashboard-status-amount { font-size: 20px; font-weight: 600; color: #0f172a; }
+.bwk-dashboard-status-count { font-size: 13px; color: #64748b; }
 
-.bwk-dashboard-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
-.bwk-dashboard-list-item { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; border-bottom: 1px solid #f3f4f6; padding-bottom: 10px; }
+.bwk-dashboard-breakdown { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.bwk-dashboard-breakdown-label { font-size: 14px; color: #64748b; }
+.bwk-dashboard-breakdown-value { font-weight: 600; color: #0f172a; }
+.bwk-dashboard-breakdown-value.is-negative { color: #b91c1c; }
+.bwk-dashboard-breakdown-total .bwk-dashboard-breakdown-label { color: #0f172a; font-weight: 600; }
+.bwk-dashboard-breakdown-total .bwk-dashboard-breakdown-value { font-size: 18px; }
+
+.bwk-dashboard-progress { position: relative; height: 8px; border-radius: 999px; background: rgba(148, 163, 184, 0.25); overflow: hidden; }
+.bwk-dashboard-progress-track { position: absolute; inset: 0; background: linear-gradient(90deg, rgba(148,163,184,0.25), rgba(148,163,184,0)); }
+.bwk-dashboard-progress-bar { position: absolute; inset: 0 auto 0 0; background: linear-gradient(90deg, #2563eb, #60a5fa); border-radius: 999px; }
+.bwk-dashboard-progress-label { margin: 0; font-size: 13px; color: #64748b; }
+.bwk-dashboard-progress--accent .bwk-dashboard-progress-bar { background: linear-gradient(90deg, #0ea5e9, #38bdf8); }
+
+.bwk-dashboard-meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; }
+.bwk-dashboard-meta-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: #94a3b8; display: block; }
+.bwk-dashboard-meta-value { font-size: 18px; font-weight: 600; color: #0f172a; display: block; }
+.bwk-dashboard-meta-note { margin: 0; font-size: 13px; color: #64748b; }
+
+.bwk-dashboard-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+.bwk-dashboard-list-item { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; border-bottom: 1px solid #e2e8f0; padding-bottom: 12px; }
 .bwk-dashboard-list-item:last-child { border-bottom: 0; padding-bottom: 0; }
-.bwk-dashboard-list-label { font-weight: 600; color: #1f2937; }
-.bwk-dashboard-list-count { font-size: 13px; color: #6b7280; margin-left: auto; }
-.bwk-dashboard-list-amount { font-weight: 600; color: #1d4ed8; }
+.bwk-dashboard-list-label { font-weight: 600; color: #0f172a; }
+.bwk-dashboard-list-count { font-size: 13px; color: #94a3b8; margin-left: auto; }
+.bwk-dashboard-list-amount { font-weight: 600; color: #2563eb; }
 
 .bwk-dashboard-chart { position: relative; width: 100%; }
-.bwk-dashboard-chart canvas { width: 100%; height: 260px; display: block; border-radius: 12px; background: linear-gradient(135deg, rgba(37,99,235,0.08), rgba(255,255,255,0)); }
+.bwk-dashboard-chart canvas { width: 100%; height: 260px; display: block; border-radius: 14px; background: linear-gradient(135deg, rgba(37,99,235,0.06), rgba(255,255,255,0.9)); }
 .bwk-dashboard-chart.is-empty canvas { opacity: 0.4; }
-.bwk-dashboard-chart-state { position: absolute; left: 16px; top: 16px; font-size: 13px; color: #6b7280; margin: 0; padding: 6px 10px; background: rgba(255,255,255,0.85); border-radius: 999px; box-shadow: 0 0 0 1px rgba(209,213,219,0.6); }
-.bwk-dashboard-chart-state[data-state="error"] { color: #b91c1c; background: rgba(254,226,226,0.92); box-shadow: 0 0 0 1px rgba(248,113,113,0.4); }
+.bwk-dashboard-chart-state { position: absolute; left: 16px; top: 16px; font-size: 13px; color: #64748b; margin: 0; padding: 6px 12px; background: rgba(255,255,255,0.85); border-radius: 999px; box-shadow: 0 0 0 1px rgba(148,163,184,0.4); }
+.bwk-dashboard-chart-state[data-state="error"] { color: #b91c1c; background: rgba(254, 226, 226, 0.92); box-shadow: 0 0 0 1px rgba(248,113,113,0.4); }
 
-.bwk-dashboard-legend-wrap { display: flex; flex-direction: column; gap: 10px; }
+.bwk-dashboard-legend-wrap { display: flex; flex-direction: column; gap: 12px; }
 .bwk-dashboard-legend { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
-.bwk-dashboard-legend-item { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; font-size: 13px; color: #1f2937; }
+.bwk-dashboard-legend-item { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; font-size: 13px; color: #0f172a; }
 .bwk-dashboard-legend-label { font-weight: 500; }
-.bwk-dashboard-legend-value { font-weight: 600; color: #1d4ed8; }
+.bwk-dashboard-legend-value { font-weight: 600; color: #2563eb; }
 .bwk-dashboard-legend-wrap .bwk-dashboard-empty-message { display: none; }
 .bwk-dashboard-legend-wrap.is-empty .bwk-dashboard-legend { display: none; }
 .bwk-dashboard-legend-wrap.is-empty .bwk-dashboard-empty-message { display: block; }
 
-.bwk-dashboard-activity { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 14px; }
-.bwk-dashboard-activity-item { display: flex; flex-direction: column; gap: 6px; padding-bottom: 12px; border-bottom: 1px solid #f3f4f6; }
+.bwk-dashboard-activity { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 16px; }
+.bwk-dashboard-activity-item { display: flex; flex-direction: column; gap: 8px; padding-bottom: 14px; border-bottom: 1px solid #e2e8f0; }
 .bwk-dashboard-activity-item:last-child { border-bottom: 0; padding-bottom: 0; }
 .bwk-dashboard-activity-header { display: flex; align-items: center; gap: 10px; }
-.bwk-dashboard-activity-type { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #2563eb; background: rgba(37,99,235,0.12); padding: 4px 8px; border-radius: 999px; }
-.bwk-dashboard-activity-link { font-weight: 600; color: #111827; text-decoration: none; }
+.bwk-dashboard-activity-type { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; background: rgba(37,99,235,0.12); padding: 4px 8px; border-radius: 999px; }
+.bwk-dashboard-activity-link { font-weight: 600; color: #0f172a; text-decoration: none; }
 .bwk-dashboard-activity-link:hover { color: #2563eb; }
 .bwk-dashboard-activity-status { margin-left: auto; font-size: 12px; font-weight: 600; text-transform: capitalize; padding: 4px 10px; border-radius: 999px; background: #eef2ff; color: #3730a3; }
 .bwk-dashboard-activity-status.status-paid, .bwk-dashboard-status-card.status-paid { background: #dcfce7; color: #15803d; }
@@ -68,15 +98,21 @@
 .bwk-dashboard-activity-status.status-sale { background: #e0f2fe; color: #0c4a6e; }
 .bwk-dashboard-activity-status.status-zakat { background: #fef3c7; color: #b45309; }
 
-.bwk-dashboard-activity-meta { display: flex; align-items: center; gap: 12px; font-size: 13px; color: #6b7280; }
-.bwk-dashboard-activity-amount { font-weight: 600; color: #111827; }
-.bwk-dashboard-activity-time { font-style: normal; }
+.bwk-dashboard-activity-meta { display: flex; align-items: center; gap: 12px; font-size: 13px; color: #94a3b8; }
+.bwk-dashboard-activity-amount { font-weight: 600; color: #0f172a; }
+.bwk-dashboard-activity-amount.is-negative { color: #b91c1c; }
+.bwk-dashboard-activity-amount.is-positive { color: #15803d; }
+.bwk-dashboard-activity-time { font-style: normal; color: #64748b; }
 
-.bwk-dashboard-empty-message { font-size: 13px; color: #6b7280; margin: 0; }
+.bwk-dashboard-empty-message { font-size: 13px; color: #94a3b8; margin: 0; }
+
+@media (max-width: 1024px) {
+    .bwk-dashboard-grid--feature { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+}
 
 @media (max-width: 782px) {
     .bwk-dashboard-kpi { padding: 18px; }
-    .bwk-dashboard-panel { padding: 18px; }
+    .bwk-dashboard-panel { padding: 20px; }
     .bwk-dashboard-panel-header h2 { font-size: 17px; }
     .bwk-dashboard-chart canvas { height: 220px; }
 }

--- a/bwk-accounting-lite/admin/views-dashboard.php
+++ b/bwk-accounting-lite/admin/views-dashboard.php
@@ -3,95 +3,80 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$primary_currency = isset( $primary_currency ) && $primary_currency ? $primary_currency : 'USD';
-$currency_prefix  = $primary_currency ? $primary_currency . ' ' : '';
-$invoice_summary  = isset( $invoice_summary ) && is_array( $invoice_summary ) ? $invoice_summary : array();
-$invoice_total    = isset( $invoice_summary['amount'] ) ? (float) $invoice_summary['amount'] : 0.0;
-$invoice_count    = isset( $invoice_summary['count'] ) ? (int) $invoice_summary['count'] : 0;
-$invoice_paid     = isset( $invoice_summary['paid'] ) ? (float) $invoice_summary['paid'] : 0.0;
-$invoice_due      = isset( $invoice_summary['outstanding'] ) ? (float) $invoice_summary['outstanding'] : 0.0;
+$primary_currency      = isset( $primary_currency ) && $primary_currency ? $primary_currency : 'USD';
+$currency_prefix       = $primary_currency ? $primary_currency . ' ' : '';
+$invoice_summary       = isset( $invoice_summary ) && is_array( $invoice_summary ) ? $invoice_summary : array();
+$profit_summary        = isset( $profit_summary ) && is_array( $profit_summary ) ? $profit_summary : array();
+$zakat_summary         = isset( $zakat_summary ) && is_array( $zakat_summary ) ? $zakat_summary : array();
 $invoice_status_totals = isset( $invoice_status_totals ) && is_array( $invoice_status_totals ) ? $invoice_status_totals : array();
 $quote_status_totals   = isset( $quote_status_totals ) && is_array( $quote_status_totals ) ? $quote_status_totals : array();
 $recent_activity       = isset( $recent_activity ) && is_array( $recent_activity ) ? $recent_activity : array();
+
+$invoice_total = isset( $invoice_summary['amount'] ) ? (float) $invoice_summary['amount'] : 0.0;
+$invoice_count = isset( $invoice_summary['count'] ) ? (int) $invoice_summary['count'] : 0;
+$invoice_paid  = isset( $invoice_summary['paid'] ) ? (float) $invoice_summary['paid'] : 0.0;
+$invoice_due   = isset( $invoice_summary['outstanding'] ) ? (float) $invoice_summary['outstanding'] : 0.0;
+
+$profit_revenue = isset( $profit_summary['revenue'] ) ? (float) $profit_summary['revenue'] : 0.0;
+$profit_expense = isset( $profit_summary['expenses'] ) ? (float) $profit_summary['expenses'] : 0.0;
+$profit_zakat   = isset( $profit_summary['zakat'] ) ? (float) $profit_summary['zakat'] : 0.0;
+$profit_net     = isset( $profit_summary['profit'] ) ? (float) $profit_summary['profit'] : 0.0;
+$profit_margin  = isset( $profit_summary['margin'] ) ? (float) $profit_summary['margin'] : 0.0;
+
+$profit_margin_display = number_format_i18n( $profit_margin, 1 );
+$profit_margin_message = $profit_margin >= 0
+    ? sprintf( __( '%s%% margin', 'bwk-accounting-lite' ), $profit_margin_display )
+    : sprintf( __( '%s%% loss', 'bwk-accounting-lite' ), number_format_i18n( abs( $profit_margin ), 1 ) );
+$profit_margin_progress = $profit_margin > 0 ? min( 100, $profit_margin ) : 0;
+$profit_class           = $profit_net >= 0 ? ' is-positive' : ' is-negative';
+
+$zakat_expected = isset( $zakat_summary['expected'] ) ? (float) $zakat_summary['expected'] : 0.0;
+$zakat_recorded = isset( $zakat_summary['recorded'] ) ? (float) $zakat_summary['recorded'] : 0.0;
+$zakat_pending  = isset( $zakat_summary['pending'] ) ? (float) $zakat_summary['pending'] : 0.0;
+$zakat_rate     = isset( $zakat_summary['rate'] ) ? (float) $zakat_summary['rate'] : 0.0;
+$zakat_progress = isset( $zakat_summary['progress'] ) ? (float) $zakat_summary['progress'] : 0.0;
+$zakat_progress = max( 0, min( 100, $zakat_progress ) );
+$last_zakat     = isset( $zakat_summary['last_contribution'] ) ? $zakat_summary['last_contribution'] : null;
+
+$paid_ratio = $invoice_total > 0 ? round( ( $invoice_paid / $invoice_total ) * 100 ) : 0;
+$due_ratio  = $invoice_total > 0 ? round( ( $invoice_due / $invoice_total ) * 100 ) : 0;
+
 ?>
 <div class="wrap bwk-dashboard-wrap">
-    <h1><?php esc_html_e( 'Accounting Dashboard', 'bwk-accounting-lite' ); ?></h1>
+    <div class="bwk-dashboard-heading">
+        <h1><?php esc_html_e( 'Accounting Dashboard', 'bwk-accounting-lite' ); ?></h1>
+        <p class="bwk-dashboard-subtitle"><?php esc_html_e( 'Monitor cash flow, track Zakat obligations, and stay ahead of your invoicing pipeline.', 'bwk-accounting-lite' ); ?></p>
+    </div>
 
     <div class="bwk-dashboard-kpis">
-        <div class="bwk-dashboard-kpi">
+        <article class="bwk-dashboard-kpi">
             <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Total Invoiced', 'bwk-accounting-lite' ); ?></span>
             <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $invoice_total, 2 ) ); ?></span>
             <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( sprintf( _n( '%s invoice recorded', '%s invoices recorded', $invoice_count, 'bwk-accounting-lite' ), number_format_i18n( $invoice_count ) ) ); ?></span>
-        </div>
-        <div class="bwk-dashboard-kpi">
+        </article>
+        <article class="bwk-dashboard-kpi">
             <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Paid to Date', 'bwk-accounting-lite' ); ?></span>
             <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $invoice_paid, 2 ) ); ?></span>
-            <?php
-            $paid_ratio = $invoice_total > 0 ? round( ( $invoice_paid / $invoice_total ) * 100 ) : 0;
-            ?>
             <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( sprintf( __( '%s%% of invoiced total', 'bwk-accounting-lite' ), number_format_i18n( $paid_ratio ) ) ); ?></span>
-        </div>
-        <div class="bwk-dashboard-kpi">
+        </article>
+        <article class="bwk-dashboard-kpi">
             <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Outstanding Balance', 'bwk-accounting-lite' ); ?></span>
             <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $invoice_due, 2 ) ); ?></span>
-            <?php
-            $due_ratio = $invoice_total > 0 ? round( ( $invoice_due / $invoice_total ) * 100 ) : 0;
-            ?>
             <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( sprintf( __( '%s%% awaiting payment', 'bwk-accounting-lite' ), number_format_i18n( $due_ratio ) ) ); ?></span>
-        </div>
+        </article>
+        <article class="bwk-dashboard-kpi bwk-dashboard-kpi--profit<?php echo esc_attr( $profit_class ); ?>">
+            <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Net Profit', 'bwk-accounting-lite' ); ?></span>
+            <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $profit_net, 2 ) ); ?></span>
+            <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( $profit_margin_message ); ?></span>
+        </article>
+        <article class="bwk-dashboard-kpi bwk-dashboard-kpi--accent">
+            <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Zakat Reserved', 'bwk-accounting-lite' ); ?></span>
+            <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $zakat_recorded, 2 ) ); ?></span>
+            <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( sprintf( __( '%s pending at %s%%', 'bwk-accounting-lite' ), $currency_prefix . number_format_i18n( $zakat_pending, 2 ), number_format_i18n( $zakat_rate, 1 ) ) ); ?></span>
+        </article>
     </div>
 
-    <div class="bwk-dashboard-grid">
-        <section class="bwk-dashboard-panel">
-            <header class="bwk-dashboard-panel-header">
-                <h2><?php esc_html_e( 'Invoice Status Overview', 'bwk-accounting-lite' ); ?></h2>
-            </header>
-            <div class="bwk-dashboard-status-grid">
-                <?php foreach ( $invoice_status_totals as $status => $row ) :
-                    $fallback_label = ucwords( str_replace( array( '-', '_' ), ' ', (string) $status ) );
-                    $label = isset( $row['label'] ) ? $row['label'] : $fallback_label;
-                    $count = isset( $row['count'] ) ? (int) $row['count'] : 0;
-                    $total = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
-                    $status_class = $status ? ' status-' . sanitize_html_class( $status ) : '';
-                    ?>
-                    <div class="bwk-dashboard-status-card<?php echo esc_attr( $status_class ); ?>">
-                        <span class="bwk-dashboard-status-label"><?php echo esc_html( $label ); ?></span>
-                        <span class="bwk-dashboard-status-amount"><?php echo esc_html( $currency_prefix . number_format_i18n( $total, 2 ) ); ?></span>
-                        <span class="bwk-dashboard-status-count"><?php echo esc_html( sprintf( _n( '%s invoice', '%s invoices', $count, 'bwk-accounting-lite' ), number_format_i18n( $count ) ) ); ?></span>
-                    </div>
-                <?php endforeach; ?>
-            </div>
-        </section>
-        <section class="bwk-dashboard-panel">
-            <header class="bwk-dashboard-panel-header">
-                <h2><?php esc_html_e( 'Quote Pipeline', 'bwk-accounting-lite' ); ?></h2>
-            </header>
-            <ul class="bwk-dashboard-list">
-                <?php
-                $has_quote_activity = false;
-                foreach ( $quote_status_totals as $status => $row ) :
-                    $fallback_label = ucwords( str_replace( array( '-', '_' ), ' ', (string) $status ) );
-                    $label = isset( $row['label'] ) ? $row['label'] : $fallback_label;
-                    $count = isset( $row['count'] ) ? (int) $row['count'] : 0;
-                    $total = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
-                    if ( $count > 0 || $total > 0 ) {
-                        $has_quote_activity = true;
-                    }
-                    ?>
-                    <li class="bwk-dashboard-list-item">
-                        <span class="bwk-dashboard-list-label"><?php echo esc_html( $label ); ?></span>
-                        <span class="bwk-dashboard-list-count"><?php echo esc_html( sprintf( _n( '%s quote', '%s quotes', $count, 'bwk-accounting-lite' ), number_format_i18n( $count ) ) ); ?></span>
-                        <span class="bwk-dashboard-list-amount"><?php echo esc_html( $currency_prefix . number_format_i18n( $total, 2 ) ); ?></span>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-            <?php if ( ! $has_quote_activity ) : ?>
-                <p class="bwk-dashboard-empty-message"><?php esc_html_e( 'No quotes recorded yet. Create one to start tracking your pipeline.', 'bwk-accounting-lite' ); ?></p>
-            <?php endif; ?>
-        </section>
-    </div>
-
-    <div class="bwk-dashboard-grid">
+    <div class="bwk-dashboard-grid bwk-dashboard-grid--feature">
         <section class="bwk-dashboard-panel bwk-dashboard-panel-chart">
             <header class="bwk-dashboard-panel-header">
                 <h2><?php esc_html_e( 'Revenue Trend', 'bwk-accounting-lite' ); ?></h2>
@@ -107,26 +92,158 @@ $recent_activity       = isset( $recent_activity ) && is_array( $recent_activity
         </section>
         <section class="bwk-dashboard-panel">
             <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Profit Breakdown', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <ul class="bwk-dashboard-breakdown">
+                <li>
+                    <span class="bwk-dashboard-breakdown-label"><?php esc_html_e( 'Revenue', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-breakdown-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $profit_revenue, 2 ) ); ?></span>
+                </li>
+                <li>
+                    <span class="bwk-dashboard-breakdown-label"><?php esc_html_e( 'Expenses', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-breakdown-value is-negative"><?php echo esc_html( $currency_prefix . number_format_i18n( $profit_expense, 2 ) ); ?></span>
+                </li>
+                <li>
+                    <span class="bwk-dashboard-breakdown-label"><?php esc_html_e( 'Zakat Allocation', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-breakdown-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $profit_zakat, 2 ) ); ?></span>
+                </li>
+                <li class="bwk-dashboard-breakdown-total">
+                    <span class="bwk-dashboard-breakdown-label"><?php esc_html_e( 'Net Profit', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-breakdown-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $profit_net, 2 ) ); ?></span>
+                </li>
+            </ul>
+            <div class="bwk-dashboard-progress">
+                <div class="bwk-dashboard-progress-track"></div>
+                <div class="bwk-dashboard-progress-bar" style="width: <?php echo esc_attr( $profit_margin_progress ); ?>%;"></div>
+            </div>
+            <p class="bwk-dashboard-progress-label"><?php echo esc_html( $profit_margin_message ); ?></p>
+        </section>
+    </div>
+
+    <div class="bwk-dashboard-grid">
+        <section class="bwk-dashboard-panel">
+            <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Invoice Status Overview', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <div class="bwk-dashboard-status-grid">
+                <?php foreach ( $invoice_status_totals as $status => $row ) :
+                    $fallback_label = ucwords( str_replace( array( '-', '_' ), ' ', (string) $status ) );
+                    $label          = isset( $row['label'] ) ? $row['label'] : $fallback_label;
+                    $count          = isset( $row['count'] ) ? (int) $row['count'] : 0;
+                    $total          = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
+                    $status_class   = $status ? ' status-' . sanitize_html_class( $status ) : '';
+                    ?>
+                    <div class="bwk-dashboard-status-card<?php echo esc_attr( $status_class ); ?>">
+                        <span class="bwk-dashboard-status-label"><?php echo esc_html( $label ); ?></span>
+                        <span class="bwk-dashboard-status-amount"><?php echo esc_html( $currency_prefix . number_format_i18n( $total, 2 ) ); ?></span>
+                        <span class="bwk-dashboard-status-count"><?php echo esc_html( sprintf( _n( '%s invoice', '%s invoices', $count, 'bwk-accounting-lite' ), number_format_i18n( $count ) ) ); ?></span>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <section class="bwk-dashboard-panel">
+            <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Zakat Tracker', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <div class="bwk-dashboard-meta-grid">
+                <div>
+                    <span class="bwk-dashboard-meta-label"><?php esc_html_e( 'Expected', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-meta-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $zakat_expected, 2 ) ); ?></span>
+                </div>
+                <div>
+                    <span class="bwk-dashboard-meta-label"><?php esc_html_e( 'Recorded', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-meta-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $zakat_recorded, 2 ) ); ?></span>
+                </div>
+                <div>
+                    <span class="bwk-dashboard-meta-label"><?php esc_html_e( 'Pending', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-meta-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $zakat_pending, 2 ) ); ?></span>
+                </div>
+                <div>
+                    <span class="bwk-dashboard-meta-label"><?php esc_html_e( 'Zakat Rate', 'bwk-accounting-lite' ); ?></span>
+                    <span class="bwk-dashboard-meta-value"><?php echo esc_html( number_format_i18n( $zakat_rate, 1 ) . '%' ); ?></span>
+                </div>
+            </div>
+            <div class="bwk-dashboard-progress bwk-dashboard-progress--accent">
+                <div class="bwk-dashboard-progress-track"></div>
+                <div class="bwk-dashboard-progress-bar" style="width: <?php echo esc_attr( $zakat_progress ); ?>%;"></div>
+            </div>
+            <?php if ( $last_zakat && ! empty( $last_zakat['timestamp'] ) ) :
+                $timestamp     = (int) $last_zakat['timestamp'];
+                $last_currency = isset( $last_zakat['currency'] ) && $last_zakat['currency'] ? $last_zakat['currency'] : $primary_currency;
+                $last_amount   = isset( $last_zakat['amount'] ) ? abs( (float) $last_zakat['amount'] ) : 0.0;
+                $time_diff     = human_time_diff( $timestamp, current_time( 'timestamp' ) );
+                $datetime_attr = wp_date( 'c', $timestamp );
+
+                $amount_text = esc_html( $last_currency . ' ' . number_format_i18n( $last_amount, 2 ) );
+                $time_text   = '<time datetime="' . esc_attr( $datetime_attr ) . '">' . esc_html( $time_diff ) . '</time>';
+                $message     = sprintf(
+                    /* translators: 1: amount, 2: relative time */
+                    __( 'Last contribution of %1$s was recorded %2$s ago.', 'bwk-accounting-lite' ),
+                    $amount_text,
+                    $time_text
+                );
+                ?>
+                <p class="bwk-dashboard-meta-note"><?php echo wp_kses( $message, array( 'time' => array( 'datetime' => true ) ) ); ?></p>
+            <?php else : ?>
+                <p class="bwk-dashboard-meta-note"><?php esc_html_e( 'No Zakat contributions have been logged yet.', 'bwk-accounting-lite' ); ?></p>
+            <?php endif; ?>
+        </section>
+    </div>
+
+    <div class="bwk-dashboard-grid">
+        <section class="bwk-dashboard-panel">
+            <header class="bwk-dashboard-panel-header">
+                <h2><?php esc_html_e( 'Quote Pipeline', 'bwk-accounting-lite' ); ?></h2>
+            </header>
+            <ul class="bwk-dashboard-list">
+                <?php
+                $has_quote_activity = false;
+                foreach ( $quote_status_totals as $status => $row ) :
+                    $fallback_label = ucwords( str_replace( array( '-', '_' ), ' ', (string) $status ) );
+                    $label          = isset( $row['label'] ) ? $row['label'] : $fallback_label;
+                    $count          = isset( $row['count'] ) ? (int) $row['count'] : 0;
+                    $total          = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
+                    if ( $count > 0 || $total > 0 ) {
+                        $has_quote_activity = true;
+                    }
+                    ?>
+                    <li class="bwk-dashboard-list-item">
+                        <span class="bwk-dashboard-list-label"><?php echo esc_html( $label ); ?></span>
+                        <span class="bwk-dashboard-list-count"><?php echo esc_html( sprintf( _n( '%s quote', '%s quotes', $count, 'bwk-accounting-lite' ), number_format_i18n( $count ) ) ); ?></span>
+                        <span class="bwk-dashboard-list-amount"><?php echo esc_html( $currency_prefix . number_format_i18n( $total, 2 ) ); ?></span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+            <?php if ( ! $has_quote_activity ) : ?>
+                <p class="bwk-dashboard-empty-message"><?php esc_html_e( 'No quotes recorded yet. Create one to start tracking your pipeline.', 'bwk-accounting-lite' ); ?></p>
+            <?php endif; ?>
+        </section>
+        <section class="bwk-dashboard-panel">
+            <header class="bwk-dashboard-panel-header">
                 <h2><?php esc_html_e( 'Recent Activity', 'bwk-accounting-lite' ); ?></h2>
             </header>
             <?php if ( $recent_activity ) : ?>
                 <ul class="bwk-dashboard-activity">
                     <?php foreach ( $recent_activity as $activity ) :
-                        $type_label   = isset( $activity['type_label'] ) ? $activity['type_label'] : '';
-                        $title        = isset( $activity['title'] ) ? $activity['title'] : '';
-                        $url          = isset( $activity['url'] ) ? $activity['url'] : '';
-                        $status       = isset( $activity['status'] ) ? $activity['status'] : '';
-                        $status_label = isset( $activity['status_label'] ) ? $activity['status_label'] : '';
-                        $status_class = $status ? ' status-' . sanitize_html_class( $status ) : '';
-                        $amount_value = isset( $activity['total'] ) ? (float) $activity['total'] : null;
+                        $type_label    = isset( $activity['type_label'] ) ? $activity['type_label'] : '';
+                        $title         = isset( $activity['title'] ) ? $activity['title'] : '';
+                        $url           = isset( $activity['url'] ) ? $activity['url'] : '';
+                        $status        = isset( $activity['status'] ) ? $activity['status'] : '';
+                        $status_label  = isset( $activity['status_label'] ) ? $activity['status_label'] : '';
+                        $status_class  = $status ? ' status-' . sanitize_html_class( $status ) : '';
+                        $amount_value  = isset( $activity['total'] ) ? (float) $activity['total'] : null;
                         $activity_currency = isset( $activity['currency'] ) && $activity['currency'] ? $activity['currency'] : $primary_currency;
-                        $amount_display = null === $amount_value ? '' : $activity_currency . ' ' . number_format_i18n( $amount_value, 2 );
-                        $timestamp  = isset( $activity['timestamp'] ) ? (int) $activity['timestamp'] : 0;
-                        $time_phrase = '';
+                        $amount_display = null === $amount_value ? '' : $activity_currency . ' ' . number_format_i18n( abs( $amount_value ), 2 );
+                        $timestamp     = isset( $activity['timestamp'] ) ? (int) $activity['timestamp'] : 0;
+                        $time_phrase   = '';
                         $datetime_attr = '';
                         if ( $timestamp ) {
-                            $time_phrase  = human_time_diff( $timestamp, current_time( 'timestamp' ) );
+                            $time_phrase   = human_time_diff( $timestamp, current_time( 'timestamp' ) );
                             $datetime_attr = wp_date( 'c', $timestamp );
+                        }
+                        $amount_class = '';
+                        if ( null !== $amount_value ) {
+                            $amount_class = $amount_value < 0 ? ' is-negative' : ' is-positive';
                         }
                         ?>
                         <li class="bwk-dashboard-activity-item">
@@ -145,7 +262,7 @@ $recent_activity       = isset( $recent_activity ) && is_array( $recent_activity
                             </div>
                             <div class="bwk-dashboard-activity-meta">
                                 <?php if ( '' !== $amount_display ) : ?>
-                                    <span class="bwk-dashboard-activity-amount"><?php echo esc_html( $amount_display ); ?></span>
+                                    <span class="bwk-dashboard-activity-amount<?php echo esc_attr( $amount_class ); ?>"><?php echo esc_html( $amount_display ); ?></span>
                                 <?php endif; ?>
                                 <?php if ( $time_phrase ) : ?>
                                     <time class="bwk-dashboard-activity-time" datetime="<?php echo esc_attr( $datetime_attr ); ?>"><?php echo esc_html( sprintf( __( '%s ago', 'bwk-accounting-lite' ), $time_phrase ) ); ?></time>

--- a/bwk-accounting-lite/includes/class-admin-menu.php
+++ b/bwk-accounting-lite/includes/class-admin-menu.php
@@ -16,7 +16,8 @@ class BWK_Admin_Menu {
 
     public static function register_menu() {
         $cap = 'manage_options';
-        add_menu_page( __( 'BWK Dashboard', 'bwk-accounting-lite' ), __( 'BWK Accounting', 'bwk-accounting-lite' ), $cap, 'bwk-dashboard', array( 'BWK_Dashboard', 'render_page' ), 'dashicons-chart-area', 56 );
+        $dashboard_hook = add_menu_page( __( 'BWK Dashboard', 'bwk-accounting-lite' ), __( 'BWK Accounting', 'bwk-accounting-lite' ), $cap, 'bwk-dashboard', array( 'BWK_Dashboard', 'render_page' ), 'dashicons-chart-area', 56 );
+        BWK_Dashboard::set_screen_hook( $dashboard_hook );
         add_submenu_page( 'bwk-dashboard', __( 'Dashboard', 'bwk-accounting-lite' ), __( 'Dashboard', 'bwk-accounting-lite' ), $cap, 'bwk-dashboard', array( 'BWK_Dashboard', 'render_page' ) );
         add_submenu_page( 'bwk-dashboard', __( 'Invoices', 'bwk-accounting-lite' ), __( 'Invoices', 'bwk-accounting-lite' ), $cap, 'bwk-accounting', array( 'BWK_Invoices', 'render_list_page' ) );
         add_submenu_page( 'bwk-dashboard', __( 'Add New Invoice', 'bwk-accounting-lite' ), __( 'Add New', 'bwk-accounting-lite' ), $cap, 'bwk-invoice-add', array( 'BWK_Invoices', 'render_edit_page' ) );


### PR DESCRIPTION
## Summary
- extend `BWK_Dashboard` to register screen hooks, aggregate profit/Zakat metrics, and serve the dashboard view
- wire the main admin menu to the dashboard renderer and capture its screen hook suffix
- rebuild the dashboard template and styles into a modern card layout with profit, revenue, and Zakat tracking

## Testing
- php -l bwk-accounting-lite/includes/class-dashboard.php
- php -l bwk-accounting-lite/includes/class-admin-menu.php
- php -l bwk-accounting-lite/admin/views-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cf110af7688330a4f17c0f8466f176