### PR TITLE
Add profit analytics pipeline for dashboard and REST API

### DIFF
--- a/bwk-accounting-lite/admin/views-dashboard.php
+++ b/bwk-accounting-lite/admin/views-dashboard.php
@@ -10,6 +10,15 @@ $invoice_total    = isset( $invoice_summary['amount'] ) ? (float) $invoice_summa
 $invoice_count    = isset( $invoice_summary['count'] ) ? (int) $invoice_summary['count'] : 0;
 $invoice_paid     = isset( $invoice_summary['paid'] ) ? (float) $invoice_summary['paid'] : 0.0;
 $invoice_due      = isset( $invoice_summary['outstanding'] ) ? (float) $invoice_summary['outstanding'] : 0.0;
+$profit_summary   = isset( $profit_summary ) && is_array( $profit_summary ) ? $profit_summary : array();
+$profit_currency  = isset( $profit_summary['currency'] ) && $profit_summary['currency'] ? $profit_summary['currency'] : $primary_currency;
+$profit_prefix    = $profit_currency ? $profit_currency . ' ' : '';
+$profit_net       = isset( $profit_summary['net'] ) ? (float) $profit_summary['net'] : 0.0;
+$profit_sales     = isset( $profit_summary['sales'] ) ? (float) $profit_summary['sales'] : 0.0;
+$profit_refunds   = isset( $profit_summary['refunds'] ) ? (float) $profit_summary['refunds'] : 0.0;
+$profit_expenses  = isset( $profit_summary['expenses'] ) ? (float) $profit_summary['expenses'] : 0.0;
+$profit_costs     = isset( $profit_summary['costs'] ) ? (float) $profit_summary['costs'] : 0.0;
+$profit_window_label = isset( $profit_window_label ) ? (string) $profit_window_label : '';
 $invoice_status_totals = isset( $invoice_status_totals ) && is_array( $invoice_status_totals ) ? $invoice_status_totals : array();
 $quote_status_totals   = isset( $quote_status_totals ) && is_array( $quote_status_totals ) ? $quote_status_totals : array();
 $recent_activity       = isset( $recent_activity ) && is_array( $recent_activity ) ? $recent_activity : array();
@@ -18,6 +27,24 @@ $recent_activity       = isset( $recent_activity ) && is_array( $recent_activity
     <h1><?php esc_html_e( 'Accounting Dashboard', 'bwk-accounting-lite' ); ?></h1>
 
     <div class="bwk-dashboard-kpis">
+        <div class="bwk-dashboard-kpi">
+            <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Net Profit', 'bwk-accounting-lite' ); ?></span>
+            <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $profit_prefix . number_format_i18n( $profit_net, 2 ) ); ?></span>
+            <?php if ( $profit_window_label ) : ?>
+                <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( $profit_window_label ); ?></span>
+            <?php endif; ?>
+            <?php
+            $profit_breakdown = sprintf(
+                /* translators: 1: sales total, 2: refunds total, 3: expenses total, 4: cost of goods total. */
+                __( 'Sales %1$s, refunds %2$s, expenses %3$s, costs %4$s', 'bwk-accounting-lite' ),
+                $profit_prefix . number_format_i18n( $profit_sales, 2 ),
+                $profit_prefix . number_format_i18n( $profit_refunds, 2 ),
+                $profit_prefix . number_format_i18n( $profit_expenses, 2 ),
+                $profit_prefix . number_format_i18n( $profit_costs, 2 )
+            );
+            ?>
+            <span class="bwk-dashboard-kpi-meta"><?php echo esc_html( $profit_breakdown ); ?></span>
+        </div>
         <div class="bwk-dashboard-kpi">
             <span class="bwk-dashboard-kpi-label"><?php esc_html_e( 'Total Invoiced', 'bwk-accounting-lite' ); ?></span>
             <span class="bwk-dashboard-kpi-value"><?php echo esc_html( $currency_prefix . number_format_i18n( $invoice_total, 2 ) ); ?></span>
@@ -94,7 +121,7 @@ $recent_activity       = isset( $recent_activity ) && is_array( $recent_activity
     <div class="bwk-dashboard-grid">
         <section class="bwk-dashboard-panel bwk-dashboard-panel-chart">
             <header class="bwk-dashboard-panel-header">
-                <h2><?php esc_html_e( 'Revenue Trend', 'bwk-accounting-lite' ); ?></h2>
+                <h2><?php esc_html_e( 'Net Profit Trend', 'bwk-accounting-lite' ); ?></h2>
             </header>
             <div class="bwk-dashboard-chart">
                 <canvas id="bwk-dashboard-chart"></canvas>

--- a/bwk-accounting-lite/includes/class-ledger.php
+++ b/bwk-accounting-lite/includes/class-ledger.php
@@ -12,6 +12,88 @@ class BWK_Ledger {
         // placeholder for hooks.
     }
 
+    /**
+     * Calculate net profit for a given range.
+     *
+     * @param array $args {
+     *     Optional. Calculation arguments.
+     *
+     *     @type string|int $start    Start datetime (string parsable by strtotime) or timestamp.
+     *     @type string|int $end      End datetime (string parsable by strtotime) or timestamp.
+     *     @type string     $currency Limit results to a specific currency code.
+     *     @type string     $source   Limit results to a specific source identifier.
+     * }
+     *
+     * @return array
+     */
+    public static function calculate_profit( $args = array() ) {
+        global $wpdb;
+
+        $defaults = array(
+            'start'    => null,
+            'end'      => null,
+            'currency' => null,
+            'source'   => null,
+        );
+
+        $args     = wp_parse_args( $args, $defaults );
+        $currency = self::normalize_currency( $args['currency'] );
+        $start    = self::normalize_datetime( $args['start'], 'start' );
+        $end      = self::normalize_datetime( $args['end'], 'end' );
+
+        $where  = array();
+        $params = array();
+
+        if ( $start ) {
+            $where[]  = 'txn_date >= %s';
+            $params[] = $start;
+        }
+
+        if ( $end ) {
+            $where[]  = 'txn_date <= %s';
+            $params[] = $end;
+        }
+
+        if ( $currency ) {
+            $where[]  = 'currency = %s';
+            $params[] = $currency;
+        }
+
+        if ( ! empty( $args['source'] ) ) {
+            $where[]  = 'source = %s';
+            $params[] = sanitize_key( $args['source'] );
+        }
+
+        $sql = 'SELECT txn_type, amount, currency, txn_date, meta_json FROM ' . bwk_table_ledger() . ' WHERE 1=1';
+
+        if ( $where ) {
+            $sql .= ' AND ' . implode( ' AND ', $where );
+        }
+
+        $sql .= ' ORDER BY txn_date ASC';
+
+        $rows = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A ) : $wpdb->get_results( $sql, ARRAY_A );
+
+        if ( ! $currency && $rows ) {
+            $first_row = reset( $rows );
+
+            if ( $first_row && isset( $first_row['currency'] ) ) {
+                $currency = self::normalize_currency( $first_row['currency'] );
+            }
+        }
+
+        $summary = self::summarize_profit_rows(
+            $rows,
+            array(
+                'currency' => $currency,
+                'start'    => $start,
+                'end'      => $end,
+            )
+        );
+
+        return apply_filters( 'bwk_ledger_calculate_profit', $summary, $args, $rows );
+    }
+
     public static function insert_entry( $data ) {
         global $wpdb;
         $defaults = array(
@@ -25,6 +107,122 @@ class BWK_Ledger {
         );
         $data = wp_parse_args( $data, $defaults );
         $wpdb->insert( bwk_table_ledger(), $data );
+    }
+
+    /**
+     * Build a profit series grouped by month.
+     *
+     * @param array $args {
+     *     Optional. Series arguments.
+     *
+     *     @type int    $months   Number of months to include. Defaults to 6.
+     *     @type string $currency Currency code to constrain results.
+     * }
+     *
+     * @return array
+     */
+    public static function get_profit_series( $args = array() ) {
+        global $wpdb;
+
+        $defaults = array(
+            'months'   => 6,
+            'currency' => null,
+        );
+
+        $args     = wp_parse_args( $args, $defaults );
+        $months   = max( 1, absint( $args['months'] ) );
+        $currency = self::normalize_currency( $args['currency'] );
+
+        $end_ts   = current_time( 'timestamp' );
+        $start_ts = strtotime( '-' . ( $months - 1 ) . ' months', $end_ts );
+        $start_ts = $start_ts ? $start_ts : $end_ts;
+
+        $start_date = wp_date( 'Y-m-01 00:00:00', $start_ts );
+        $end_date   = wp_date( 'Y-m-t 23:59:59', $end_ts );
+
+        $where  = array( 'txn_date >= %s', 'txn_date <= %s' );
+        $params = array( $start_date, $end_date );
+
+        if ( $currency ) {
+            $where[]  = 'currency = %s';
+            $params[] = $currency;
+        }
+
+        $sql   = 'SELECT txn_type, amount, currency, txn_date, meta_json FROM ' . bwk_table_ledger() . ' WHERE ' . implode( ' AND ', $where ) . ' ORDER BY txn_date ASC';
+        $rows  = $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );
+
+        if ( ! $currency && $rows ) {
+            $first_row = reset( $rows );
+
+            if ( $first_row && isset( $first_row['currency'] ) ) {
+                $currency = self::normalize_currency( $first_row['currency'] );
+            }
+        }
+        $buckets = array();
+
+        if ( $rows ) {
+            foreach ( $rows as $row ) {
+                if ( empty( $row['txn_date'] ) ) {
+                    continue;
+                }
+
+                $timestamp = strtotime( $row['txn_date'] );
+
+                if ( false === $timestamp ) {
+                    continue;
+                }
+
+                $period_key = wp_date( 'Y-m-01', $timestamp );
+
+                if ( ! isset( $buckets[ $period_key ] ) ) {
+                    $buckets[ $period_key ] = array();
+                }
+
+                $buckets[ $period_key ][] = $row;
+            }
+        }
+
+        $labels = array();
+        $values = array();
+        $series = array();
+
+        for ( $i = $months - 1; $i >= 0; $i-- ) {
+            $month_ts  = strtotime( '-' . $i . ' months', $end_ts );
+            $month_ts  = $month_ts ? $month_ts : $end_ts;
+            $period_key = wp_date( 'Y-m-01', $month_ts );
+            $period_rows = isset( $buckets[ $period_key ] ) ? $buckets[ $period_key ] : array();
+
+            $summary = self::summarize_profit_rows(
+                $period_rows,
+                array(
+                    'currency' => $currency,
+                    'start'    => wp_date( 'Y-m-01 00:00:00', $month_ts ),
+                    'end'      => wp_date( 'Y-m-t 23:59:59', $month_ts ),
+                )
+            );
+
+            $labels[]        = wp_date( 'M Y', $month_ts );
+            $values[]        = isset( $summary['net'] ) ? (float) $summary['net'] : 0.0;
+            $series[ $period_key ] = $summary;
+        }
+
+        $currency_value = $currency ? $currency : '';
+
+        $result = array(
+            'labels'   => $labels,
+            'values'   => array_map(
+                static function ( $value ) {
+                    return round( (float) $value, 2 );
+                },
+                $values
+            ),
+            'currency' => $currency_value,
+            'series'   => $series,
+            'start'    => $start_date,
+            'end'      => $end_date,
+        );
+
+        return apply_filters( 'bwk_ledger_profit_series', $result, $args, $rows );
     }
 
     public static function insert_zakat( $invoice_id, $amount, $currency ) {
@@ -44,5 +242,207 @@ class BWK_Ledger {
         global $wpdb;
         $entries = $wpdb->get_results( 'SELECT * FROM ' . bwk_table_ledger() . ' ORDER BY txn_date DESC LIMIT 200' );
         include BWK_AL_PATH . 'admin/views-ledger-list.php';
+    }
+
+    /**
+     * Convert ledger rows into profit totals.
+     *
+     * @param array $rows    Ledger rows.
+     * @param array $context Context data.
+     *
+     * @return array
+     */
+    protected static function summarize_profit_rows( $rows, $context = array() ) {
+        $rows = is_array( $rows ) ? $rows : array();
+
+        $sales           = 0.0;
+        $refunds         = 0.0;
+        $expenses        = 0.0;
+        $costs           = 0.0;
+        $refunded_costs  = 0.0;
+
+        $expense_types = apply_filters(
+            'bwk_ledger_profit_expense_types',
+            array( 'expense', 'fee', 'payout', 'tax', 'zakat' ),
+            $rows,
+            $context
+        );
+
+        foreach ( $rows as $row ) {
+            $txn_type = isset( $row['txn_type'] ) ? sanitize_key( $row['txn_type'] ) : '';
+            $amount   = isset( $row['amount'] ) ? (float) $row['amount'] : 0.0;
+            $meta     = self::decode_meta( isset( $row['meta_json'] ) ? $row['meta_json'] : '' );
+            $cost     = self::extract_cost_from_meta( $meta );
+
+            if ( 'sale' === $txn_type ) {
+                if ( $amount > 0 ) {
+                    $sales += $amount;
+                } else {
+                    $sales += abs( $amount );
+                }
+
+                if ( $cost > 0 ) {
+                    $costs += $cost;
+                }
+
+                continue;
+            }
+
+            if ( 'refund' === $txn_type ) {
+                $refunds += abs( $amount );
+
+                if ( $cost > 0 ) {
+                    $refunded_costs += $cost;
+                }
+
+                continue;
+            }
+
+            if ( in_array( $txn_type, $expense_types, true ) ) {
+                $expenses += abs( $amount );
+
+                continue;
+            }
+
+            /**
+             * Allow custom handling of unrecognised ledger types.
+             *
+             * @since 1.0.0
+             *
+             * @param array $row     Ledger row.
+             * @param array $context Context array.
+             */
+            do_action( 'bwk_ledger_profit_unhandled_row', $row, $context );
+        }
+
+        $net_costs = $costs - $refunded_costs;
+
+        if ( $net_costs < 0 ) {
+            $net_costs = 0.0;
+        }
+
+        $net = $sales - $refunds - $expenses - $net_costs;
+
+        $currency = isset( $context['currency'] ) ? self::normalize_currency( $context['currency'] ) : '';
+
+        $summary = array(
+            'currency'        => $currency,
+            'sales'           => round( $sales, 2 ),
+            'refunds'         => round( $refunds, 2 ),
+            'expenses'        => round( $expenses, 2 ),
+            'costs'           => round( $net_costs, 2 ),
+            'costs_gross'     => round( $costs, 2 ),
+            'refunded_costs'  => round( $refunded_costs, 2 ),
+            'net'             => round( $net, 2 ),
+            'start'           => isset( $context['start'] ) ? $context['start'] : null,
+            'end'             => isset( $context['end'] ) ? $context['end'] : null,
+        );
+
+        return apply_filters( 'bwk_ledger_profit_summary', $summary, $rows, $context );
+    }
+
+    /**
+     * Decode a meta JSON string into an array.
+     *
+     * @param string $meta_json Meta JSON string.
+     *
+     * @return array
+     */
+    protected static function decode_meta( $meta_json ) {
+        if ( empty( $meta_json ) ) {
+            return array();
+        }
+
+        $decoded = json_decode( wp_unslash( $meta_json ), true );
+
+        return is_array( $decoded ) ? $decoded : array();
+    }
+
+    /**
+     * Attempt to extract a cost total value from decoded metadata.
+     *
+     * @param array $meta Decoded metadata array.
+     *
+     * @return float
+     */
+    protected static function extract_cost_from_meta( $meta ) {
+        if ( empty( $meta ) || ! is_array( $meta ) ) {
+            return 0.0;
+        }
+
+        $keys = array( 'cost_total', 'total_cost', 'cost', 'cogs', 'cost_of_goods' );
+
+        foreach ( $keys as $key ) {
+            if ( isset( $meta[ $key ] ) && is_numeric( $meta[ $key ] ) ) {
+                return (float) $meta[ $key ];
+            }
+        }
+
+        if ( isset( $meta['totals'] ) && is_array( $meta['totals'] ) ) {
+            foreach ( $keys as $key ) {
+                if ( isset( $meta['totals'][ $key ] ) && is_numeric( $meta['totals'][ $key ] ) ) {
+                    return (float) $meta['totals'][ $key ];
+                }
+            }
+        }
+
+        if ( isset( $meta['costs'] ) && is_array( $meta['costs'] ) && isset( $meta['costs']['total'] ) && is_numeric( $meta['costs']['total'] ) ) {
+            return (float) $meta['costs']['total'];
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * Normalise a currency string into ISO-style uppercase letters.
+     *
+     * @param string $currency Currency string.
+     *
+     * @return string
+     */
+    protected static function normalize_currency( $currency ) {
+        if ( ! is_string( $currency ) ) {
+            return '';
+        }
+
+        $currency = strtoupper( preg_replace( '/[^A-Z]/', '', $currency ) );
+
+        return $currency;
+    }
+
+    /**
+     * Normalise a datetime value into MySQL format.
+     *
+     * @param mixed  $value    Datetime value.
+     * @param string $boundary Accepts 'start' or 'end' to control rounding.
+     *
+     * @return string|null
+     */
+    protected static function normalize_datetime( $value, $boundary = 'start' ) {
+        if ( empty( $value ) && 0 !== $value ) {
+            return null;
+        }
+
+        if ( $value instanceof DateTimeInterface ) {
+            $timestamp = $value->getTimestamp();
+        } elseif ( is_numeric( $value ) ) {
+            $timestamp = (int) $value;
+        } elseif ( is_string( $value ) ) {
+            $timestamp = strtotime( $value );
+        } else {
+            $timestamp = false;
+        }
+
+        if ( false === $timestamp ) {
+            return null;
+        }
+
+        if ( 'end' === $boundary ) {
+            $date_string = wp_date( 'Y-m-d 23:59:59', $timestamp );
+        } else {
+            $date_string = wp_date( 'Y-m-d 00:00:00', $timestamp );
+        }
+
+        return $date_string;
     }
 }

--- a/bwk-accounting-lite/includes/class-rest.php
+++ b/bwk-accounting-lite/includes/class-rest.php
@@ -18,6 +18,61 @@ class BWK_Rest {
             'callback'            => array( __CLASS__, 'get_invoice' ),
             'permission_callback' => '__return_true',
         ) );
+
+        register_rest_route(
+            'bwk-accounting/v1',
+            '/profit',
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( __CLASS__, 'get_profit' ),
+                    'permission_callback' => array( __CLASS__, 'permissions_check' ),
+                    'args'                => array(
+                        'start'    => array(
+                            'description' => __( 'Start datetime for the profit calculation window.', 'bwk-accounting-lite' ),
+                            'type'        => 'string',
+                            'required'    => false,
+                        ),
+                        'end'      => array(
+                            'description' => __( 'End datetime for the profit calculation window.', 'bwk-accounting-lite' ),
+                            'type'        => 'string',
+                            'required'    => false,
+                        ),
+                        'currency' => array(
+                            'description' => __( 'Currency code used to filter profit rows.', 'bwk-accounting-lite' ),
+                            'type'        => 'string',
+                            'required'    => false,
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        register_rest_route(
+            'bwk-accounting/v1',
+            '/profit/series',
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( __CLASS__, 'get_profit_series' ),
+                    'permission_callback' => array( __CLASS__, 'permissions_check' ),
+                    'args'                => array(
+                        'months'   => array(
+                            'description' => __( 'Number of months to include in the profit series.', 'bwk-accounting-lite' ),
+                            'type'        => 'integer',
+                            'default'     => 6,
+                            'minimum'     => 1,
+                            'maximum'     => 24,
+                        ),
+                        'currency' => array(
+                            'description' => __( 'Currency code used to filter profit rows.', 'bwk-accounting-lite' ),
+                            'type'        => 'string',
+                            'required'    => false,
+                        ),
+                    ),
+                ),
+            )
+        );
     }
 
     public static function get_invoice( $request ) {
@@ -41,5 +96,123 @@ class BWK_Rest {
         unset( $item );
         $invoice['items'] = $items;
         return rest_ensure_response( $invoice );
+    }
+
+    /**
+     * Verify access for REST resources.
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return bool|WP_Error
+     */
+    public static function permissions_check( $request ) {
+        if ( bwk_current_user_can() ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'rest_forbidden',
+            __( 'Sorry, you are not allowed to access this resource.', 'bwk-accounting-lite' ),
+            array( 'status' => rest_authorization_required_code() )
+        );
+    }
+
+    /**
+     * Return a profit summary for the requested window.
+     *
+     * @param WP_REST_Request $request Request data.
+     *
+     * @return WP_REST_Response|array
+     */
+    public static function get_profit( $request ) {
+        $currency = self::sanitize_currency( $request->get_param( 'currency' ) );
+        $start    = $request->get_param( 'start' );
+        $end      = $request->get_param( 'end' );
+
+        $args = array();
+
+        if ( $currency ) {
+            $args['currency'] = $currency;
+        }
+
+        if ( null !== $start && '' !== $start ) {
+            if ( is_numeric( $start ) ) {
+                $args['start'] = (int) $start;
+            } else {
+                $args['start'] = sanitize_text_field( wp_unslash( $start ) );
+            }
+        }
+
+        if ( null !== $end && '' !== $end ) {
+            if ( is_numeric( $end ) ) {
+                $args['end'] = (int) $end;
+            } else {
+                $args['end'] = sanitize_text_field( wp_unslash( $end ) );
+            }
+        }
+
+        $summary = BWK_Ledger::calculate_profit( $args );
+
+        if ( empty( $summary['currency'] ) && $currency ) {
+            $summary['currency'] = $currency;
+        }
+
+        return rest_ensure_response( $summary );
+    }
+
+    /**
+     * Return a monthly profit series for charting interfaces.
+     *
+     * @param WP_REST_Request $request Request data.
+     *
+     * @return WP_REST_Response|array
+     */
+    public static function get_profit_series( $request ) {
+        $months   = (int) $request->get_param( 'months' );
+        $currency = self::sanitize_currency( $request->get_param( 'currency' ) );
+
+        if ( $months < 1 ) {
+            $months = 1;
+        }
+
+        if ( $months > 24 ) {
+            $months = 24;
+        }
+
+        $args = array( 'months' => $months );
+
+        if ( $currency ) {
+            $args['currency'] = $currency;
+        }
+
+        $series = BWK_Ledger::get_profit_series( $args );
+
+        if ( empty( $series['currency'] ) && $currency ) {
+            $series['currency'] = $currency;
+        }
+
+        return rest_ensure_response( $series );
+    }
+
+    /**
+     * Clean a currency string received from REST requests.
+     *
+     * @param mixed $currency Raw currency value.
+     *
+     * @return string
+     */
+    protected static function sanitize_currency( $currency ) {
+        if ( null === $currency || '' === $currency ) {
+            return '';
+        }
+
+        if ( is_array( $currency ) ) {
+            return '';
+        }
+
+        $currency = sanitize_text_field( wp_unslash( $currency ) );
+        $currency = strtoupper( preg_replace( '/[^A-Z]/', '', $currency ) );
+
+        return $currency;
     }
 }

--- a/bwk-accounting-lite/includes/class-sync-woocommerce.php
+++ b/bwk-accounting-lite/includes/class-sync-woocommerce.php
@@ -21,14 +21,33 @@ class BWK_Sync_WooCommerce {
         if ( ! $order ) {
             return;
         }
+        $cost_data = self::calculate_order_cost( $order );
+        $meta      = array(
+            'status'     => $order->get_status(),
+            'cost_total' => isset( $cost_data['total'] ) ? (float) $cost_data['total'] : 0.0,
+            'items'      => isset( $cost_data['items'] ) ? $cost_data['items'] : array(),
+            'net_total'  => round( (float) $order->get_total() - ( isset( $cost_data['total'] ) ? (float) $cost_data['total'] : 0.0 ), 2 ),
+        );
+
+        /**
+         * Filter the metadata stored against a WooCommerce sale ledger entry.
+         *
+         * @since 1.0.0
+         *
+         * @param array     $meta  Metadata array.
+         * @param WC_Order  $order WooCommerce order object.
+         * @param array     $cost_data Cost breakdown.
+         */
+        $meta = apply_filters( 'bwk_wc_sale_ledger_meta', $meta, $order, $cost_data );
+
         BWK_Ledger::insert_entry( array(
             'source'    => 'wc',
             'source_id' => $order_id,
             'txn_type'  => 'sale',
             'amount'    => $order->get_total(),
             'currency'  => $order->get_currency(),
-            'txn_date'  => gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ),
-            'meta_json' => wp_json_encode( array( 'status' => $order->get_status() ) ),
+            'txn_date'  => self::format_datetime( $order->get_date_created() ),
+            'meta_json' => wp_json_encode( $meta ),
         ) );
     }
 
@@ -37,14 +56,266 @@ class BWK_Sync_WooCommerce {
         if ( ! $refund ) {
             return;
         }
+        $order     = wc_get_order( $order_id );
+        $cost_data = self::calculate_refund_cost( $refund, $order );
+        $meta      = array(
+            'parent'        => $order_id,
+            'is_refund'     => true,
+            'cost_total'    => isset( $cost_data['total'] ) ? (float) $cost_data['total'] : 0.0,
+            'items'         => isset( $cost_data['items'] ) ? $cost_data['items'] : array(),
+            'status'        => method_exists( $refund, 'get_status' ) ? $refund->get_status() : '',
+        );
+
+        if ( $order ) {
+            $meta['parent_status'] = $order->get_status();
+        }
+
+        /**
+         * Filter the metadata stored against a WooCommerce refund ledger entry.
+         *
+         * @since 1.0.0
+         *
+         * @param array           $meta      Metadata array.
+         * @param WC_Order_Refund $refund    Refund object.
+         * @param WC_Order|null   $order     Parent order object.
+         * @param array           $cost_data Cost breakdown for the refund.
+         */
+        $meta = apply_filters( 'bwk_wc_refund_ledger_meta', $meta, $refund, $order, $cost_data );
+
         BWK_Ledger::insert_entry( array(
             'source'    => 'wc',
             'source_id' => $refund_id,
             'txn_type'  => 'refund',
             'amount'    => $refund->get_total(),
             'currency'  => $refund->get_currency(),
-            'txn_date'  => gmdate( 'Y-m-d H:i:s', $refund->get_date_created()->getTimestamp() ),
-            'meta_json' => wp_json_encode( array( 'parent' => $order_id ) ),
+            'txn_date'  => self::format_datetime( $refund->get_date_created() ),
+            'meta_json' => wp_json_encode( $meta ),
         ) );
+    }
+
+    /**
+     * Prepare cost breakdown for an order.
+     *
+     * @param WC_Order $order WooCommerce order object.
+     *
+     * @return array
+     */
+    protected static function calculate_order_cost( $order ) {
+        $total_cost = 0.0;
+        $items      = array();
+
+        if ( ! $order ) {
+            return array(
+                'total' => 0.0,
+                'items' => array(),
+            );
+        }
+
+        foreach ( $order->get_items() as $item_id => $item ) {
+            if ( ! is_a( $item, 'WC_Order_Item_Product' ) ) {
+                continue;
+            }
+
+            $qty       = (float) $item->get_quantity();
+            $qty       = $qty > 0 ? $qty : 0.0;
+            $unit_cost = self::determine_unit_cost( $item );
+            $line_cost = round( $unit_cost * $qty, 2 );
+
+            $items[] = array(
+                'item_id'      => (int) $item_id,
+                'product_id'   => (int) $item->get_product_id(),
+                'variation_id' => (int) $item->get_variation_id(),
+                'qty'          => $qty,
+                'unit_cost'    => round( $unit_cost, 4 ),
+                'line_cost'    => $line_cost,
+            );
+
+            $total_cost += $line_cost;
+
+            if ( function_exists( 'wc_update_order_item_meta' ) && $item_id ) {
+                wc_update_order_item_meta( $item_id, '_bwk_cost_basis', $unit_cost );
+            }
+        }
+
+        return array(
+            'total' => round( $total_cost, 2 ),
+            'items' => $items,
+        );
+    }
+
+    /**
+     * Prepare cost data for a refund.
+     *
+     * @param WC_Order_Refund $refund Refund instance.
+     * @param WC_Order|null   $order  Parent order.
+     *
+     * @return array
+     */
+    protected static function calculate_refund_cost( $refund, $order ) {
+        $total_cost = 0.0;
+        $items      = array();
+
+        if ( ! $refund ) {
+            return array(
+                'total' => 0.0,
+                'items' => array(),
+            );
+        }
+
+        $cost_basis = array();
+
+        if ( $order ) {
+            foreach ( $order->get_items() as $item_id => $order_item ) {
+                if ( ! is_a( $order_item, 'WC_Order_Item_Product' ) ) {
+                    continue;
+                }
+
+                $basis = $order_item->get_meta( '_bwk_cost_basis', true );
+
+                if ( '' === $basis || null === $basis ) {
+                    $basis = self::determine_unit_cost( $order_item );
+                }
+
+                $cost_basis[ $item_id ] = (float) $basis;
+            }
+        }
+
+        foreach ( $refund->get_items() as $item_id => $item ) {
+            if ( ! is_a( $item, 'WC_Order_Item_Product' ) ) {
+                continue;
+            }
+
+            $qty = abs( (float) $item->get_quantity() );
+            $qty = $qty > 0 ? $qty : 0.0;
+
+            $refunded_item_id = $item->get_meta( '_refunded_item_id', true );
+            if ( ! $refunded_item_id ) {
+                $refunded_item_id = $item->get_meta( 'refunded_item_id', true );
+            }
+
+            $unit_cost = null;
+
+            if ( $refunded_item_id && isset( $cost_basis[ $refunded_item_id ] ) ) {
+                $unit_cost = $cost_basis[ $refunded_item_id ];
+            }
+
+            if ( null === $unit_cost ) {
+                $unit_cost = self::determine_unit_cost( $item );
+            }
+
+            $unit_cost = (float) $unit_cost;
+            $line_cost = round( $unit_cost * $qty, 2 );
+
+            $items[] = array(
+                'refunded_item_id' => $refunded_item_id ? (int) $refunded_item_id : null,
+                'product_id'       => (int) $item->get_product_id(),
+                'variation_id'     => (int) $item->get_variation_id(),
+                'qty'              => $qty,
+                'unit_cost'        => round( $unit_cost, 4 ),
+                'line_cost'        => $line_cost,
+            );
+
+            $total_cost += $line_cost;
+        }
+
+        return array(
+            'total' => round( $total_cost, 2 ),
+            'items' => $items,
+        );
+    }
+
+    /**
+     * Determine the unit cost for a WooCommerce order item.
+     *
+     * @param WC_Order_Item_Product $item Order item.
+     *
+     * @return float
+     */
+    protected static function determine_unit_cost( $item ) {
+        $unit_cost = null;
+        $meta_keys = self::get_cost_meta_keys();
+        $product   = is_callable( array( $item, 'get_product' ) ) ? $item->get_product() : null;
+
+        if ( $product ) {
+            foreach ( $meta_keys as $key ) {
+                $value = $product->get_meta( $key, true );
+
+                if ( '' !== $value && null !== $value ) {
+                    $unit_cost = (float) $value;
+                    break;
+                }
+            }
+        }
+
+        if ( null === $unit_cost ) {
+            foreach ( $meta_keys as $key ) {
+                $value = $item->get_meta( $key, true );
+
+                if ( '' !== $value && null !== $value ) {
+                    $unit_cost = (float) $value;
+                    break;
+                }
+            }
+        }
+
+        if ( null === $unit_cost ) {
+            $value = $item->get_meta( '_bwk_cost_basis', true );
+
+            if ( '' !== $value && null !== $value ) {
+                $unit_cost = (float) $value;
+            }
+        }
+
+        /**
+         * Filter the detected unit cost for an order item.
+         *
+         * @since 1.0.0
+         *
+         * @param float|null             $unit_cost Unit cost value or null if unknown.
+         * @param WC_Order_Item_Product  $item      Order item.
+         * @param WC_Product|false|null  $product   Related product instance.
+         */
+        $unit_cost = apply_filters( 'bwk_wc_order_item_unit_cost', $unit_cost, $item, $product );
+
+        if ( null === $unit_cost || ! is_numeric( $unit_cost ) ) {
+            $unit_cost = 0.0;
+        }
+
+        return (float) $unit_cost;
+    }
+
+    /**
+     * Retrieve the list of product meta keys checked for unit costs.
+     *
+     * @return array
+     */
+    protected static function get_cost_meta_keys() {
+        $keys = array(
+            '_bwk_cost',
+            '_cost',
+            '_wc_cost',
+            '_purchase_price',
+            '_wc_cog_cost',
+            '_wc_cog_cost_price',
+            '_wc_cogs_cost',
+            'cost_of_goods',
+        );
+
+        return apply_filters( 'bwk_wc_cost_meta_keys', $keys );
+    }
+
+    /**
+     * Format a WooCommerce datetime into the ledger timestamp.
+     *
+     * @param DateTimeInterface|null $datetime Datetime instance.
+     *
+     * @return string
+     */
+    protected static function format_datetime( $datetime ) {
+        if ( $datetime instanceof DateTimeInterface ) {
+            return gmdate( 'Y-m-d H:i:s', $datetime->getTimestamp() );
+        }
+
+        return gmdate( 'Y-m-d H:i:s' );
     }
 }


### PR DESCRIPTION
## Summary
- add ledger helpers to calculate net profit over configurable ranges and generate monthly series data
- capture WooCommerce order and refund cost metadata so ledger entries support accurate profit math
- surface profit metrics on the admin dashboard and expose them via new REST endpoints for cards and charts

## Testing
- php -l bwk-accounting-lite/includes/class-ledger.php
- php -l bwk-accounting-lite/includes/class-sync-woocommerce.php
- php -l bwk-accounting-lite/includes/class-dashboard.php
- php -l bwk-accounting-lite/includes/class-rest.php
- php -l bwk-accounting-lite/admin/views-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cf11150a208330b6ffdb6f0c66a9e6