### PR TITLE
Extract WooCommerce product search to dedicated admin class

### DIFF
--- a/bwk-accounting-lite/bwk-accounting-lite.php
+++ b/bwk-accounting-lite/bwk-accounting-lite.php
@@ -38,6 +38,7 @@ function bwk_accounting_lite_init() {
     BWK_Settings::init();
     BWK_Dashboard::init();
     BWK_Admin_Menu::init();
+    BWK_Admin_Products::init();
     BWK_Invoices::init();
     BWK_Quotes_Table::init();
     BWK_Ledger::init();

--- a/bwk-accounting-lite/includes/class-admin-products.php
+++ b/bwk-accounting-lite/includes/class-admin-products.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Admin product helpers.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class BWK_Admin_Products {
+    /**
+     * Boot hooks.
+     */
+    public static function init() {
+        add_action( 'wp_ajax_bwk_search_products', array( __CLASS__, 'search_products' ) );
+    }
+
+    /**
+     * AJAX handler for WooCommerce product lookup.
+     */
+    public static function search_products() {
+        if ( ! bwk_current_user_can() ) {
+            wp_send_json_error( array( 'message' => __( 'Access denied.', 'bwk-accounting-lite' ) ) );
+        }
+
+        check_ajax_referer( 'bwk_search_products', 'nonce' );
+
+        if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'wc_get_products' ) ) {
+            wp_send_json_error( array( 'message' => __( 'WooCommerce is not active.', 'bwk-accounting-lite' ) ) );
+        }
+
+        $term = isset( $_REQUEST['term'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['term'] ) ) : '';
+
+        if ( strlen( $term ) < 2 ) {
+            wp_send_json_success( array( 'items' => array() ) );
+        }
+
+        $query_args = array(
+            'status'  => array( 'publish' ),
+            'limit'   => 20,
+            'orderby' => 'title',
+            'order'   => 'ASC',
+            'return'  => 'objects',
+        );
+
+        $products = wc_get_products(
+            array_merge(
+                $query_args,
+                array(
+                    'search' => '*' . $term . '*',
+                )
+            )
+        );
+
+        $sku_matches = wc_get_products(
+            array_merge(
+                $query_args,
+                array(
+                    'sku' => $term,
+                )
+            )
+        );
+
+        if ( $sku_matches ) {
+            $products = array_merge( $products, $sku_matches );
+        }
+
+        $items    = array();
+        $seen_ids = array();
+
+        foreach ( $products as $product ) {
+            if ( ! $product instanceof WC_Product ) {
+                continue;
+            }
+
+            $product_id = $product->get_id();
+
+            if ( isset( $seen_ids[ $product_id ] ) ) {
+                continue;
+            }
+
+            $price = function_exists( 'wc_get_price_to_display' ) ? wc_get_price_to_display( $product ) : $product->get_price();
+            $price = is_numeric( $price ) ? (float) $price : 0.0;
+
+            $items[] = array(
+                'id'    => $product_id,
+                'name'  => $product->get_name(),
+                'sku'   => $product->get_sku(),
+                'price' => $price,
+            );
+
+            $seen_ids[ $product_id ] = true;
+        }
+
+        wp_send_json_success( array( 'items' => $items ) );
+    }
+}

--- a/bwk-accounting-lite/includes/class-ajax.php
+++ b/bwk-accounting-lite/includes/class-ajax.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BWK_Ajax {
     public static function init() {
         add_action( 'wp_ajax_bwk_import_wc_orders', array( __CLASS__, 'import_wc_orders' ) );
-        add_action( 'wp_ajax_bwk_search_products', array( __CLASS__, 'search_products' ) );
     }
 
     public static function import_wc_orders() {
@@ -22,68 +21,4 @@ class BWK_Ajax {
         wp_send_json_success( array( 'done' => true ) );
     }
 
-    public static function search_products() {
-        if ( ! bwk_current_user_can() ) {
-            wp_send_json_error( array( 'message' => __( 'Access denied.', 'bwk-accounting-lite' ) ) );
-        }
-
-        check_ajax_referer( 'bwk_search_products', 'nonce' );
-
-        if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'wc_get_products' ) ) {
-            wp_send_json_error( array( 'message' => __( 'WooCommerce is not active.', 'bwk-accounting-lite' ) ) );
-        }
-
-        $term = isset( $_REQUEST['term'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['term'] ) ) : '';
-        if ( strlen( $term ) < 2 ) {
-            wp_send_json_success( array( 'items' => array() ) );
-        }
-
-        $args = array(
-            'status'  => array( 'publish' ),
-            'limit'   => 20,
-            'orderby' => 'title',
-            'order'   => 'ASC',
-            'return'  => 'objects',
-        );
-
-        $products = wc_get_products( array_merge( $args, array(
-            'search' => '*' . $term . '*',
-        ) ) );
-
-        $sku_matches = wc_get_products( array_merge( $args, array(
-            'sku' => $term,
-        ) ) );
-
-        if ( $sku_matches ) {
-            $products = array_merge( $products, $sku_matches );
-        }
-
-        $items    = array();
-        $seen_ids = array();
-
-        foreach ( $products as $product ) {
-            if ( ! $product instanceof WC_Product ) {
-                continue;
-            }
-
-            $product_id = $product->get_id();
-            if ( isset( $seen_ids[ $product_id ] ) ) {
-                continue;
-            }
-
-            $price = function_exists( 'wc_get_price_to_display' ) ? wc_get_price_to_display( $product ) : $product->get_price();
-            $price = is_numeric( $price ) ? (float) $price : 0.0;
-
-            $items[] = array(
-                'id'    => $product_id,
-                'name'  => $product->get_name(),
-                'sku'   => $product->get_sku(),
-                'price' => $price,
-            );
-
-            $seen_ids[ $product_id ] = true;
-        }
-
-        wp_send_json_success( array( 'items' => $items ) );
-    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `BWK_Admin_Products` class that wires the authenticated WooCommerce product search endpoint for the admin
- register the new admin product helper during plugin bootstrap so the JavaScript picker can use the endpoint
- simplify the generic AJAX helper now that product search lives in its own focused class

## Testing
- php -l bwk-accounting-lite/includes/class-admin-products.php
- php -l bwk-accounting-lite/includes/class-ajax.php
- php -l bwk-accounting-lite/bwk-accounting-lite.php

------
https://chatgpt.com/codex/tasks/task_e_68cf111a5fa083309443c19acc5928f6