### PR TITLE
Add preview invoice number helper for new invoices

### DIFF
--- a/bwk-accounting-lite/includes/class-invoices-tables.php
+++ b/bwk-accounting-lite/includes/class-invoices-tables.php
@@ -36,7 +36,7 @@ class BWK_Invoices {
             $invoice = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_invoices() . ' WHERE id=%d', $id ) );
             $items   = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM ' . bwk_table_invoice_items() . ' WHERE invoice_id=%d ORDER BY line_no ASC', $id ) );
         }
-        $next_invoice_number = null;
+        $next_invoice_number = '';
         if ( ! $invoice ) {
             $next_invoice_number = bwk_preview_invoice_number();
         }

--- a/bwk-accounting-lite/includes/helpers.php
+++ b/bwk-accounting-lite/includes/helpers.php
@@ -43,21 +43,25 @@ function bwk_update_option( $key, $value ) {
     update_option( 'bwk_accounting_' . $key, $value );
 }
 
+function bwk_format_invoice_number( $sequence ) {
+    $prefix = bwk_get_option( 'number_prefix', 'INV-' );
+    $pad    = (int) bwk_get_option( 'number_padding', 4 );
+
+    return $prefix . str_pad( (string) $sequence, $pad, '0', STR_PAD_LEFT );
+}
+
 function bwk_next_invoice_number() {
     $seq = (int) bwk_get_option( 'invoice_seq', 0 );
     $seq++;
     bwk_update_option( 'invoice_seq', $seq );
-    $prefix = bwk_get_option( 'number_prefix', 'INV-' );
-    $pad    = (int) bwk_get_option( 'number_padding', 4 );
-    return $prefix . str_pad( (string) $seq, $pad, '0', STR_PAD_LEFT );
+    return bwk_format_invoice_number( $seq );
 }
 
 function bwk_preview_invoice_number() {
     $seq = (int) bwk_get_option( 'invoice_seq', 0 );
     $seq++;
-    $prefix = bwk_get_option( 'number_prefix', 'INV-' );
-    $pad    = (int) bwk_get_option( 'number_padding', 4 );
-    return $prefix . str_pad( (string) $seq, $pad, '0', STR_PAD_LEFT );
+
+    return bwk_format_invoice_number( $seq );
 }
 
 function bwk_next_quote_number() {


### PR DESCRIPTION
## Summary
- add a formatter to preview the next invoice number without mutating the stored counter
- supply the previewed invoice number to the edit form when creating a new invoice, while keeping the existing value for edits

## Testing
- php -l bwk-accounting-lite/includes/helpers.php
- php -l bwk-accounting-lite/includes/class-invoices-tables.php

------
https://chatgpt.com/codex/tasks/task_e_68cf1120b38883308b1359d17df0d96c