### PR TITLE
Normalize ledger range handling and add timezone regression tests

### DIFF
--- a/bwk-accounting-lite/composer.json
+++ b/bwk-accounting-lite/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "wan-mohd-aiman/accounting-lite",
+    "description": "Development tooling for BWK Accounting Lite tests.",
+    "type": "project",
+    "license": "GPL-2.0-or-later",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
+    "autoload": {
+        "files": []
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "": "includes/",
+            "BWK\\Tests\\": "tests/"
+        }
+    },
+    "authors": [
+        {
+            "name": "Wan Mohd Aiman Binawebpro.com"
+        }
+    ],
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
+    "minimum-stability": "stable"
+}

--- a/bwk-accounting-lite/includes/class-ledger.php
+++ b/bwk-accounting-lite/includes/class-ledger.php
@@ -1,6 +1,9 @@
 <?php
 /**
  * Ledger handling.
+ *
+ * @package BWK Accounting Lite
+ * @author Wan Mohd Aiman Binawebpro.com
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -8,6 +11,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class BWK_Ledger {
+    /**
+     * Transaction type buckets used when calculating profit and loss.
+     *
+     * @var array
+     */
+    protected static $revenue_types = array( 'sale', 'income', 'revenue', 'payment', 'deposit' );
+
+    /**
+     * Expense oriented transaction types.
+     *
+     * @var array
+     */
+    protected static $expense_types = array( 'expense', 'purchase', 'cost', 'payout', 'withdrawal', 'refund' );
+
+    /**
+     * Zakat transaction types.
+     *
+     * @var array
+     */
+    protected static $zakat_types = array( 'zakat' );
+
     public static function init() {
         // placeholder for hooks.
     }
@@ -44,5 +68,555 @@ class BWK_Ledger {
         global $wpdb;
         $entries = $wpdb->get_results( 'SELECT * FROM ' . bwk_table_ledger() . ' ORDER BY txn_date DESC LIMIT 200' );
         include BWK_AL_PATH . 'admin/views-ledger-list.php';
+    }
+
+    /**
+     * Summarise profit metrics for a date range.
+     *
+     * @param array $args Range arguments.
+     *
+     * @return array
+     */
+    public static function get_profit_summary( $args = array() ) {
+        global $wpdb;
+
+        $range = self::normalise_range( $args );
+        $meta  = $range['meta'];
+        $sql   = $range['sql'];
+
+        $table = bwk_table_ledger();
+        $query = 'SELECT LOWER(txn_type) AS txn_type, SUM(amount) AS total FROM ' . $table . ' WHERE 1=1';
+        $params = array();
+
+        if ( ! empty( $sql['start'] ) ) {
+            $query   .= ' AND txn_date >= %s';
+            $params[] = $sql['start'];
+        }
+
+        if ( ! empty( $sql['end'] ) ) {
+            $query   .= ' AND txn_date <= %s';
+            $params[] = $sql['end'];
+        }
+
+        $query .= ' GROUP BY txn_type';
+
+        $prepared = self::prepare_query( $query, $params );
+        $rows     = $wpdb->get_results( $prepared, ARRAY_A );
+
+        $totals = array(
+            'revenue'  => 0.0,
+            'expenses' => 0.0,
+            'zakat'    => 0.0,
+        );
+
+        if ( $rows ) {
+            foreach ( $rows as $row ) {
+                $type   = isset( $row['txn_type'] ) ? self::normalise_key( $row['txn_type'] ) : '';
+                $amount = isset( $row['total'] ) ? (float) $row['total'] : 0.0;
+
+                foreach ( self::map_amount_to_buckets( $type, $amount ) as $bucket => $value ) {
+                    if ( isset( $totals[ $bucket ] ) ) {
+                        $totals[ $bucket ] += $value;
+                    }
+                }
+            }
+        }
+
+        $revenue  = self::round_money( $totals['revenue'] );
+        $expenses = self::round_money( $totals['expenses'] );
+        $zakat    = self::round_money( $totals['zakat'] );
+        $profit   = self::round_money( $revenue - $expenses - $zakat );
+        $margin   = $revenue > 0 ? round( ( $profit / $revenue ) * 100, 2 ) : 0.0;
+
+        return array(
+            'range'    => $meta,
+            'currency' => self::get_default_currency(),
+            'revenue'  => $revenue,
+            'expenses' => $expenses,
+            'zakat'    => $zakat,
+            'profit'   => $profit,
+            'margin'   => $margin,
+        );
+    }
+
+    /**
+     * Retrieve profit series data grouped by day.
+     *
+     * @param array $args Range arguments.
+     *
+     * @return array
+     */
+    public static function get_profit_series( $args = array() ) {
+        global $wpdb;
+
+        $range    = self::normalise_range( $args );
+        $meta     = $range['meta'];
+        $sql      = $range['sql'];
+        $bounds   = $range['bounds'];
+        $timezone = self::get_timezone();
+
+        $table  = bwk_table_ledger();
+        $query  = 'SELECT txn_type, amount, currency, txn_date FROM ' . $table . ' WHERE 1=1';
+        $params = array();
+
+        if ( ! empty( $sql['start'] ) ) {
+            $query   .= ' AND txn_date >= %s';
+            $params[] = $sql['start'];
+        }
+
+        if ( ! empty( $sql['end'] ) ) {
+            $query   .= ' AND txn_date <= %s';
+            $params[] = $sql['end'];
+        }
+
+        $query .= ' ORDER BY txn_date ASC';
+
+        $prepared = self::prepare_query( $query, $params );
+        $rows     = $wpdb->get_results( $prepared, ARRAY_A );
+
+        $buckets = self::create_daily_buckets( $bounds['start'], $bounds['end'] );
+
+        if ( $rows ) {
+            foreach ( $rows as $row ) {
+                $txn_date = isset( $row['txn_date'] ) ? $row['txn_date'] : '';
+                $datetime = self::create_local_from_gmt( $txn_date, $timezone );
+
+                if ( ! $datetime ) {
+                    continue;
+                }
+
+                $key = $datetime->format( 'Y-m-d' );
+
+                if ( ! isset( $buckets[ $key ] ) ) {
+                    continue;
+                }
+
+                $type   = isset( $row['txn_type'] ) ? self::normalise_key( $row['txn_type'] ) : '';
+                $amount = isset( $row['amount'] ) ? (float) $row['amount'] : 0.0;
+
+                foreach ( self::map_amount_to_buckets( $type, $amount ) as $bucket => $value ) {
+                    if ( isset( $buckets[ $key ][ $bucket ] ) ) {
+                        $buckets[ $key ][ $bucket ] += $value;
+                    }
+                }
+            }
+        }
+
+        $labels   = array();
+        $revenue  = array();
+        $expenses = array();
+        $zakat    = array();
+        $profit   = array();
+
+        foreach ( $buckets as $key => $data ) {
+            $labels[]   = $key;
+            $revenue[]  = self::round_money( $data['revenue'] );
+            $expenses[] = self::round_money( $data['expenses'] );
+            $zakat[]    = self::round_money( $data['zakat'] );
+            $profit[]   = self::round_money( $data['revenue'] - $data['expenses'] - $data['zakat'] );
+        }
+
+        return array(
+            'range'    => $meta,
+            'currency' => self::get_default_currency(),
+            'labels'   => $labels,
+            'revenue'  => $revenue,
+            'expenses' => $expenses,
+            'zakat'    => $zakat,
+            'profit'   => $profit,
+        );
+    }
+
+    /**
+     * Normalise range arguments, returning local metadata and GMT bounds.
+     *
+     * @param array $args Arguments supplied to the query.
+     *
+     * @return array
+     */
+    protected static function normalise_range( $args ) {
+        $defaults = array(
+            'range' => 'this_month',
+            'start' => '',
+            'end'   => '',
+        );
+
+        $args     = self::parse_args( $args, $defaults );
+        $range    = isset( $args['range'] ) ? strtolower( (string) $args['range'] ) : 'this_month';
+        $timezone = self::get_timezone();
+        $now      = new DateTimeImmutable( 'now', $timezone );
+
+        $start = null;
+        $end   = null;
+        $label = '';
+
+        switch ( $range ) {
+            case 'custom':
+                $start = self::parse_user_datetime( isset( $args['start'] ) ? $args['start'] : '', $timezone, false );
+                $end   = self::parse_user_datetime( isset( $args['end'] ) ? $args['end'] : '', $timezone, true );
+                $label = 'custom';
+                break;
+            case 'last_7_days':
+            case 'last_30_days':
+            case 'last_90_days':
+                $days  = (int) preg_replace( '/[^0-9]/', '', $range );
+                $label = $range;
+                $end   = $now->setTime( 23, 59, 59 );
+                $start = $end->modify( '-' . max( 0, $days - 1 ) . ' days' )->setTime( 0, 0, 0 );
+                break;
+            case 'previous_month':
+            case 'last_month':
+                $label = 'previous_month';
+                $end   = $now->modify( 'first day of this month -1 second' )->setTime( 23, 59, 59 );
+                $start = $end->modify( 'first day of this month' )->setTime( 0, 0, 0 );
+                break;
+            case 'this_month':
+            default:
+                $label = 'this_month';
+                $start = $now->modify( 'first day of this month' )->setTime( 0, 0, 0 );
+                $end   = $start->modify( 'last day of this month' )->setTime( 23, 59, 59 );
+                break;
+        }
+
+        if ( ! $start ) {
+            $start = $now->setTime( 0, 0, 0 );
+        }
+
+        if ( ! $end ) {
+            $end = $now->setTime( 23, 59, 59 );
+        }
+
+        if ( $start > $end ) {
+            $temp  = $start;
+            $start = $end;
+            $end   = $temp;
+        }
+
+        $start_local = $start->format( 'Y-m-d H:i:s' );
+        $end_local   = $end->format( 'Y-m-d H:i:s' );
+
+        $start_gmt = self::to_gmt( $start_local, $timezone );
+        $end_gmt   = self::to_gmt( $end_local, $timezone );
+
+        return array(
+            'meta'   => array(
+                'range'    => $label,
+                'start'    => $start_local,
+                'end'      => $end_local,
+                'timezone' => $timezone->getName(),
+            ),
+            'sql'    => array(
+                'start' => $start_gmt,
+                'end'   => $end_gmt,
+            ),
+            'bounds' => array(
+                'start' => $start,
+                'end'   => $end,
+            ),
+        );
+    }
+
+    /**
+     * Prepare a WordPress style query using the provided parameters.
+     *
+     * @param string $query  SQL query with placeholders.
+     * @param array  $params Parameters to bind.
+     *
+     * @return string|array
+     */
+    protected static function prepare_query( $query, $params ) {
+        global $wpdb;
+
+        if ( empty( $params ) ) {
+            return $query;
+        }
+
+        if ( isset( $wpdb ) && is_object( $wpdb ) && method_exists( $wpdb, 'prepare' ) ) {
+            return $wpdb->prepare( $query, $params );
+        }
+
+        foreach ( $params as $param ) {
+            $safe = addslashes( $param );
+            $query = preg_replace( '/%s/', "'" . $safe . "'", $query, 1 );
+        }
+
+        return $query;
+    }
+
+    /**
+     * Create empty buckets for each day in the supplied range.
+     *
+     * @param DateTimeImmutable $start Start datetime.
+     * @param DateTimeImmutable $end   End datetime.
+     *
+     * @return array
+     */
+    protected static function create_daily_buckets( DateTimeImmutable $start, DateTimeImmutable $end ) {
+        $buckets = array();
+
+        if ( $start > $end ) {
+            return $buckets;
+        }
+
+        $current = $start;
+
+        while ( $current <= $end ) {
+            $key            = $current->format( 'Y-m-d' );
+            $buckets[ $key ] = array(
+                'timestamp' => $current->getTimestamp(),
+                'revenue'   => 0.0,
+                'expenses'  => 0.0,
+                'zakat'     => 0.0,
+            );
+            $current = $current->modify( '+1 day' );
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * Map a ledger amount to revenue, expenses, or zakat buckets.
+     *
+     * @param string $type   Transaction type.
+     * @param float  $amount Amount associated with the transaction.
+     *
+     * @return array
+     */
+    protected static function map_amount_to_buckets( $type, $amount ) {
+        $type   = self::normalise_key( $type );
+        $amount = (float) $amount;
+
+        if ( in_array( $type, self::$zakat_types, true ) ) {
+            return array( 'zakat' => abs( $amount ) );
+        }
+
+        if ( in_array( $type, self::$revenue_types, true ) ) {
+            if ( $amount >= 0 ) {
+                return array( 'revenue' => $amount );
+            }
+
+            return array( 'expenses' => abs( $amount ) );
+        }
+
+        if ( in_array( $type, self::$expense_types, true ) ) {
+            return array( 'expenses' => abs( $amount ) );
+        }
+
+        if ( $amount >= 0 ) {
+            return array( 'revenue' => $amount );
+        }
+
+        return array( 'expenses' => abs( $amount ) );
+    }
+
+    /**
+     * Convert a local datetime string into GMT.
+     *
+     * @param string         $datetime Local datetime string.
+     * @param DateTimeZone   $timezone Local timezone.
+     *
+     * @return string
+     */
+    protected static function to_gmt( $datetime, DateTimeZone $timezone ) {
+        if ( ! $datetime ) {
+            return $datetime;
+        }
+
+        if ( function_exists( 'get_gmt_from_date' ) ) {
+            return get_gmt_from_date( $datetime, 'Y-m-d H:i:s' );
+        }
+
+        try {
+            $local = new DateTimeImmutable( $datetime, $timezone );
+            return $local->setTimezone( new DateTimeZone( 'UTC' ) )->format( 'Y-m-d H:i:s' );
+        } catch ( Exception $exception ) {
+            return $datetime;
+        }
+    }
+
+    /**
+     * Create a local timezone datetime from a GMT string.
+     *
+     * @param string       $datetime GMT datetime string.
+     * @param DateTimeZone $timezone Target timezone.
+     *
+     * @return DateTimeImmutable|null
+     */
+    protected static function create_local_from_gmt( $datetime, DateTimeZone $timezone ) {
+        if ( ! $datetime ) {
+            return null;
+        }
+
+        try {
+            $utc = new DateTimeImmutable( $datetime, new DateTimeZone( 'UTC' ) );
+            return $utc->setTimezone( $timezone );
+        } catch ( Exception $exception ) {
+            return null;
+        }
+    }
+
+    /**
+     * Parse a user supplied datetime string in the site timezone.
+     *
+     * @param string       $value      Raw value.
+     * @param DateTimeZone $timezone   Target timezone.
+     * @param bool         $end_of_day Whether to clamp to the end of the day.
+     *
+     * @return DateTimeImmutable|null
+     */
+    protected static function parse_user_datetime( $value, DateTimeZone $timezone, $end_of_day ) {
+        if ( ! is_string( $value ) ) {
+            return null;
+        }
+
+        $value = trim( $value );
+
+        if ( '' === $value ) {
+            return null;
+        }
+
+        $formats = array( 'Y-m-d H:i:s', 'Y-m-d H:i', 'Y-m-d' );
+
+        foreach ( $formats as $format ) {
+            $datetime = DateTimeImmutable::createFromFormat( $format, $value, $timezone );
+            if ( false !== $datetime ) {
+                if ( 'Y-m-d' === $format ) {
+                    return $end_of_day ? $datetime->setTime( 23, 59, 59 ) : $datetime->setTime( 0, 0, 0 );
+                }
+
+                if ( 'Y-m-d H:i' === $format ) {
+                    $hour   = (int) $datetime->format( 'H' );
+                    $minute = (int) $datetime->format( 'i' );
+                    $second = $end_of_day ? 59 : 0;
+                    return $datetime->setTime( $hour, $minute, $second );
+                }
+
+                return $datetime;
+            }
+        }
+
+        try {
+            $datetime = new DateTimeImmutable( $value, $timezone );
+            if ( $end_of_day ) {
+                $datetime = $datetime->setTime( 23, 59, 59 );
+            }
+
+            return $datetime;
+        } catch ( Exception $exception ) {
+            return null;
+        }
+    }
+
+    /**
+     * Normalise a transaction type key without relying on WordPress helpers.
+     *
+     * @param string $key Raw key.
+     *
+     * @return string
+     */
+    protected static function normalise_key( $key ) {
+        if ( function_exists( 'sanitize_key' ) ) {
+            return sanitize_key( $key );
+        }
+
+        $key = strtolower( (string) $key );
+        return preg_replace( '/[^a-z0-9_]/', '', $key );
+    }
+
+    /**
+     * Parse arguments without relying on WordPress being loaded.
+     *
+     * @param mixed $args     Raw arguments.
+     * @param array $defaults Default values.
+     *
+     * @return array
+     */
+    protected static function parse_args( $args, $defaults ) {
+        if ( function_exists( 'wp_parse_args' ) ) {
+            return wp_parse_args( $args, $defaults );
+        }
+
+        if ( is_object( $args ) ) {
+            $args = get_object_vars( $args );
+        } elseif ( ! is_array( $args ) ) {
+            parse_str( (string) $args, $args );
+        }
+
+        if ( ! is_array( $args ) ) {
+            $args = array();
+        }
+
+        return array_merge( $defaults, $args );
+    }
+
+    /**
+     * Retrieve the site's timezone.
+     *
+     * @return DateTimeZone
+     */
+    protected static function get_timezone() {
+        if ( function_exists( 'wp_timezone' ) ) {
+            $timezone = wp_timezone();
+            if ( $timezone instanceof DateTimeZone ) {
+                return $timezone;
+            }
+        }
+
+        $timezone_string = function_exists( 'get_option' ) ? get_option( 'timezone_string' ) : '';
+
+        if ( $timezone_string ) {
+            try {
+                return new DateTimeZone( $timezone_string );
+            } catch ( Exception $exception ) {
+                // Fall through to offset handling.
+            }
+        }
+
+        $offset = function_exists( 'get_option' ) ? get_option( 'gmt_offset', 0 ) : 0;
+        if ( is_numeric( $offset ) && 0 !== (float) $offset ) {
+            $hours   = (float) $offset;
+            $seconds = (int) round( $hours * HOUR_IN_SECONDS );
+            $name    = timezone_name_from_abbr( '', $seconds, 0 );
+            if ( $name ) {
+                try {
+                    return new DateTimeZone( $name );
+                } catch ( Exception $exception ) {
+                    // Continue to default UTC fallback.
+                }
+            }
+        }
+
+        return new DateTimeZone( 'UTC' );
+    }
+
+    /**
+     * Round monetary values to two decimal places.
+     *
+     * @param float $value Raw value.
+     *
+     * @return float
+     */
+    protected static function round_money( $value ) {
+        return round( (float) $value, 2 );
+    }
+
+    /**
+     * Determine the default currency to report.
+     *
+     * @return string
+     */
+    protected static function get_default_currency() {
+        $currency = 'USD';
+
+        if ( function_exists( 'bwk_get_option' ) ) {
+            $stored = bwk_get_option( 'default_currency', 'USD' );
+            if ( is_string( $stored ) && '' !== $stored ) {
+                $currency = $stored;
+            }
+        }
+
+        $currency = strtoupper( preg_replace( '/[^A-Z]/', '', (string) $currency ) );
+
+        return $currency ? $currency : 'USD';
     }
 }

--- a/bwk-accounting-lite/phpunit.xml.dist
+++ b/bwk-accounting-lite/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="BWK Accounting Lite">
+            <file>tests/LedgerProfitTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/bwk-accounting-lite/tests/LedgerProfitTest.php
+++ b/bwk-accounting-lite/tests/LedgerProfitTest.php
@@ -1,0 +1,103 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LedgerProfitTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb, $_bwk_timezone_string, $_bwk_test_options;
+
+        $wpdb->reset();
+
+        $_bwk_timezone_string = 'Asia/Kuala_Lumpur';
+        $_bwk_test_options    = array();
+
+        update_option( 'timezone_string', 'Asia/Kuala_Lumpur' );
+        update_option( 'bwk_accounting_default_currency', 'MYR' );
+    }
+
+    public function test_profit_summary_includes_utc_orders_with_local_range() {
+        $this->seed_ledger_entries();
+
+        $summary = BWK_Ledger::get_profit_summary(
+            array(
+                'range' => 'custom',
+                'start' => '2024-01-01',
+                'end'   => '2024-01-31',
+            )
+        );
+
+        $this->assertArrayHasKey( 'range', $summary );
+        $this->assertSame( '2024-01-01 00:00:00', $summary['range']['start'] );
+        $this->assertSame( '2024-01-31 23:59:59', $summary['range']['end'] );
+        $this->assertSame( 'Asia/Kuala_Lumpur', $summary['range']['timezone'] );
+
+        $this->assertEquals( 250.0, $summary['revenue'] );
+        $this->assertEquals( 30.0, $summary['expenses'] );
+        $this->assertEquals( 5.0, $summary['zakat'] );
+        $this->assertEquals( 215.0, $summary['profit'] );
+    }
+
+    public function test_profit_series_buckets_use_local_timezone() {
+        $this->seed_ledger_entries();
+
+        $series = BWK_Ledger::get_profit_series(
+            array(
+                'range' => 'custom',
+                'start' => '2024-01-01',
+                'end'   => '2024-01-31',
+            )
+        );
+
+        $this->assertArrayHasKey( 'labels', $series );
+        $labels = $series['labels'];
+        $this->assertContains( '2024-01-01', $labels );
+        $this->assertContains( '2024-01-15', $labels );
+        $this->assertContains( '2024-01-21', $labels );
+        $this->assertContains( '2024-01-31', $labels );
+
+        $map = array();
+        foreach ( $labels as $index => $label ) {
+            $map[ $label ] = array(
+                'revenue'  => $series['revenue'][ $index ],
+                'expenses' => $series['expenses'][ $index ],
+                'zakat'    => $series['zakat'][ $index ],
+                'profit'   => $series['profit'][ $index ],
+            );
+        }
+
+        $this->assertEquals( 100.0, $map['2024-01-01']['revenue'] );
+        $this->assertEquals( 100.0, $map['2024-01-01']['profit'] );
+
+        $this->assertEquals( 30.0, $map['2024-01-15']['expenses'] );
+        $this->assertEquals( -30.0, $map['2024-01-15']['profit'] );
+
+        $this->assertEquals( 5.0, $map['2024-01-21']['zakat'] );
+        $this->assertEquals( -5.0, $map['2024-01-21']['profit'] );
+
+        $this->assertEquals( 150.0, $map['2024-01-31']['revenue'] );
+        $this->assertEquals( 150.0, $map['2024-01-31']['profit'] );
+    }
+
+    protected function seed_ledger_entries() {
+        $this->add_entry( 'sale', 100.00, '2023-12-31 16:15:00' );
+        $this->add_entry( 'sale', 150.00, '2024-01-31 15:45:00' );
+        $this->add_entry( 'expense', -30.00, '2024-01-15 04:00:00' );
+        $this->add_entry( 'zakat', 5.00, '2024-01-20 16:00:00' );
+        $this->add_entry( 'sale', 75.00, '2023-12-31 15:45:00' );
+    }
+
+    protected function add_entry( $type, $amount, $utc_datetime, $currency = 'MYR' ) {
+        global $wpdb;
+
+        $wpdb->insert(
+            bwk_table_ledger(),
+            array(
+                'source'    => 'wc',
+                'source_id' => rand( 1, 1000 ),
+                'txn_type'  => $type,
+                'amount'    => $amount,
+                'currency'  => $currency,
+                'txn_date'  => $utc_datetime,
+            )
+        );
+    }
+}

--- a/bwk-accounting-lite/tests/bootstrap.php
+++ b/bwk-accounting-lite/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+require __DIR__ . '/stubs/functions.php';
+require __DIR__ . '/stubs/class-test-wpdb.php';
+
+global $wpdb;
+$wpdb = new BWK_Test_WPDB();
+
+require __DIR__ . '/../includes/helpers.php';
+require __DIR__ . '/../includes/class-ledger.php';

--- a/bwk-accounting-lite/tests/manual-ledger-check.php
+++ b/bwk-accounting-lite/tests/manual-ledger-check.php
@@ -1,0 +1,77 @@
+<?php
+require __DIR__ . '/bootstrap.php';
+
+// Configure timezone and options as in tests.
+$_bwk_timezone_string = 'Asia/Kuala_Lumpur';
+update_option( 'timezone_string', 'Asia/Kuala_Lumpur' );
+update_option( 'bwk_accounting_default_currency', 'MYR' );
+
+// Reset ledger data.
+$wpdb->reset();
+
+$insert = function ( $type, $amount, $utc_datetime, $currency = 'MYR' ) use ( $wpdb ) {
+    $wpdb->insert(
+        bwk_table_ledger(),
+        array(
+            'source'    => 'wc',
+            'source_id' => rand( 1, 1000 ),
+            'txn_type'  => $type,
+            'amount'    => $amount,
+            'currency'  => $currency,
+            'txn_date'  => $utc_datetime,
+        )
+    );
+};
+
+$insert( 'sale', 100.00, '2023-12-31 16:15:00' );
+$insert( 'sale', 150.00, '2024-01-31 15:45:00' );
+$insert( 'expense', -30.00, '2024-01-15 04:00:00' );
+$insert( 'zakat', 5.00, '2024-01-20 16:00:00' );
+$insert( 'sale', 75.00, '2023-12-31 15:45:00' );
+
+$summary = BWK_Ledger::get_profit_summary(
+    array(
+        'range' => 'custom',
+        'start' => '2024-01-01',
+        'end'   => '2024-01-31',
+    )
+);
+
+$series = BWK_Ledger::get_profit_series(
+    array(
+        'range' => 'custom',
+        'start' => '2024-01-01',
+        'end'   => '2024-01-31',
+    )
+);
+
+$assertions = array();
+$assertions[] = abs( $summary['revenue'] - 250.0 ) < 0.001;
+$assertions[] = abs( $summary['expenses'] - 30.0 ) < 0.001;
+$assertions[] = abs( $summary['zakat'] - 5.0 ) < 0.001;
+$assertions[] = abs( $summary['profit'] - 215.0 ) < 0.001;
+
+$map = array();
+foreach ( $series['labels'] as $index => $label ) {
+    $map[ $label ] = array(
+        'revenue'  => $series['revenue'][ $index ],
+        'expenses' => $series['expenses'][ $index ],
+        'zakat'    => $series['zakat'][ $index ],
+        'profit'   => $series['profit'][ $index ],
+    );
+}
+
+$assertions[] = isset( $map['2024-01-01'] ) && abs( $map['2024-01-01']['revenue'] - 100.0 ) < 0.001;
+$assertions[] = isset( $map['2024-01-01'] ) && abs( $map['2024-01-01']['profit'] - 100.0 ) < 0.001;
+$assertions[] = isset( $map['2024-01-15'] ) && abs( $map['2024-01-15']['expenses'] - 30.0 ) < 0.001;
+$assertions[] = isset( $map['2024-01-15'] ) && abs( $map['2024-01-15']['profit'] + 30.0 ) < 0.001;
+$assertions[] = isset( $map['2024-01-21'] ) && abs( $map['2024-01-21']['zakat'] - 5.0 ) < 0.001;
+$assertions[] = isset( $map['2024-01-21'] ) && abs( $map['2024-01-21']['profit'] + 5.0 ) < 0.001;
+$assertions[] = isset( $map['2024-01-31'] ) && abs( $map['2024-01-31']['revenue'] - 150.0 ) < 0.001;
+$assertions[] = isset( $map['2024-01-31'] ) && abs( $map['2024-01-31']['profit'] - 150.0 ) < 0.001;
+
+$passed = array_reduce( $assertions, function ( $carry, $value ) {
+    return $carry && $value;
+}, true );
+
+echo $passed ? "All manual ledger checks passed\n" : "Manual ledger checks failed\n";

--- a/bwk-accounting-lite/tests/stubs/class-test-wpdb.php
+++ b/bwk-accounting-lite/tests/stubs/class-test-wpdb.php
@@ -1,0 +1,219 @@
+<?php
+class BWK_Test_WPDB {
+    public $prefix = 'wp_';
+
+    /**
+     * @var array
+     */
+    private $ledger = array();
+
+    /**
+     * @var int
+     */
+    private $auto_increment = 1;
+
+    /**
+     * Reset stored ledger rows.
+     */
+    public function reset() {
+        $this->ledger         = array();
+        $this->auto_increment = 1;
+    }
+
+    /**
+     * Mimic $wpdb->insert().
+     *
+     * @param string $table Target table name.
+     * @param array  $data  Row data.
+     *
+     * @return bool
+     */
+    public function insert( $table, $data ) {
+        if ( $table !== $this->prefix . 'bwk_ledger' ) {
+            return false;
+        }
+
+        $row = array_merge(
+            array(
+                'id'        => $this->auto_increment++,
+                'source'    => '',
+                'source_id' => 0,
+                'txn_type'  => '',
+                'amount'    => 0.0,
+                'currency'  => 'USD',
+                'txn_date'  => gmdate( 'Y-m-d H:i:s' ),
+                'meta_json' => '',
+            ),
+            $data
+        );
+
+        $this->ledger[] = $row;
+
+        return true;
+    }
+
+    /**
+     * Mimic $wpdb->prepare().
+     *
+     * @param string $query Query with placeholders.
+     * @param mixed  ...$args Parameters to bind.
+     *
+     * @return array
+     */
+    public function prepare( $query, ...$args ) {
+        if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+            $args = $args[0];
+        }
+
+        return array(
+            'query'  => $query,
+            'params' => $args,
+        );
+    }
+
+    /**
+     * Mimic $wpdb->get_results().
+     *
+     * @param mixed  $prepared Prepared statement representation.
+     * @param string $output   Not used.
+     *
+     * @return array
+     */
+    public function get_results( $prepared, $output = ARRAY_A ) {
+        if ( is_array( $prepared ) ) {
+            $query  = isset( $prepared['query'] ) ? $prepared['query'] : '';
+            $params = isset( $prepared['params'] ) ? $prepared['params'] : array();
+        } else {
+            $query  = (string) $prepared;
+            $params = array();
+        }
+
+        if ( false !== strpos( $query, 'GROUP BY txn_type' ) ) {
+            return $this->group_by_type( $params );
+        }
+
+        if ( false !== strpos( $query, 'ORDER BY txn_date' ) ) {
+            return $this->select_rows( $params );
+        }
+
+        return array();
+    }
+
+    /**
+     * Mimic $wpdb->get_var().
+     *
+     * @param mixed $prepared Prepared statement representation.
+     *
+     * @return string|null
+     */
+    public function get_var( $prepared ) {
+        if ( is_array( $prepared ) ) {
+            $query  = isset( $prepared['query'] ) ? $prepared['query'] : '';
+            $params = isset( $prepared['params'] ) ? $prepared['params'] : array();
+        } else {
+            $query  = (string) $prepared;
+            $params = array();
+        }
+
+        if ( false !== strpos( $query, 'SELECT currency' ) ) {
+            $rows = $this->select_rows( $params );
+            if ( empty( $rows ) ) {
+                return null;
+            }
+            $row = end( $rows );
+            return isset( $row['currency'] ) ? $row['currency'] : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Group rows by type.
+     *
+     * @param array $params Range parameters.
+     *
+     * @return array
+     */
+    private function group_by_type( $params ) {
+        list( $start, $end ) = $this->parse_range_params( $params );
+        $rows = $this->filter_rows( $start, $end );
+
+        $grouped = array();
+        foreach ( $rows as $row ) {
+            $type = strtolower( isset( $row['txn_type'] ) ? $row['txn_type'] : '' );
+            if ( ! isset( $grouped[ $type ] ) ) {
+                $grouped[ $type ] = array(
+                    'txn_type' => $type,
+                    'total'    => 0.0,
+                    'count'    => 0,
+                );
+            }
+
+            $grouped[ $type ]['total'] += (float) $row['amount'];
+            $grouped[ $type ]['count'] ++;
+        }
+
+        return array_values( $grouped );
+    }
+
+    /**
+     * Select raw rows ordered by date.
+     *
+     * @param array $params Range parameters.
+     *
+     * @return array
+     */
+    private function select_rows( $params ) {
+        list( $start, $end ) = $this->parse_range_params( $params );
+        $rows = $this->filter_rows( $start, $end );
+
+        usort(
+            $rows,
+            function ( $a, $b ) {
+                return strcmp( $a['txn_date'], $b['txn_date'] );
+            }
+        );
+
+        return $rows;
+    }
+
+    /**
+     * Filter ledger rows using start/end parameters.
+     *
+     * @param string|null $start Start bound.
+     * @param string|null $end   End bound.
+     *
+     * @return array
+     */
+    private function filter_rows( $start, $end ) {
+        return array_values(
+            array_filter(
+                $this->ledger,
+                function ( $row ) use ( $start, $end ) {
+                    $date = isset( $row['txn_date'] ) ? $row['txn_date'] : '';
+                    if ( $start && $date < $start ) {
+                        return false;
+                    }
+                    if ( $end && $date > $end ) {
+                        return false;
+                    }
+                    return true;
+                }
+            )
+        );
+    }
+
+    /**
+     * Extract start and end parameters from a prepared statement.
+     *
+     * @param array $params Prepared parameters.
+     *
+     * @return array
+     */
+    private function parse_range_params( $params ) {
+        $start = isset( $params[0] ) ? $params[0] : null;
+        $end   = isset( $params[1] ) ? $params[1] : null;
+
+        return array( $start, $end );
+    }
+}

--- a/bwk-accounting-lite/tests/stubs/functions.php
+++ b/bwk-accounting-lite/tests/stubs/functions.php
@@ -1,0 +1,96 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/../../' );
+}
+
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+global $_bwk_test_options;
+if ( ! isset( $_bwk_test_options ) ) {
+    $_bwk_test_options = array();
+}
+
+global $_bwk_timezone_string;
+if ( ! isset( $_bwk_timezone_string ) ) {
+    $_bwk_timezone_string = 'UTC';
+}
+
+function get_option( $name, $default = false ) {
+    global $_bwk_test_options;
+    return array_key_exists( $name, $_bwk_test_options ) ? $_bwk_test_options[ $name ] : $default;
+}
+
+function update_option( $name, $value ) {
+    global $_bwk_test_options;
+    $_bwk_test_options[ $name ] = $value;
+    return true;
+}
+
+function wp_parse_args( $args, $defaults = array() ) {
+    if ( is_object( $args ) ) {
+        $args = get_object_vars( $args );
+    } elseif ( ! is_array( $args ) ) {
+        parse_str( (string) $args, $args );
+    }
+
+    if ( ! is_array( $args ) ) {
+        $args = array();
+    }
+
+    return array_merge( $defaults, $args );
+}
+
+function sanitize_key( $key ) {
+    $key = strtolower( (string) $key );
+    return preg_replace( '/[^a-z0-9_]/', '', $key );
+}
+
+function absint( $maybeint ) {
+    return abs( intval( $maybeint ) );
+}
+
+function wp_timezone() {
+    global $_bwk_timezone_string;
+    return new DateTimeZone( $_bwk_timezone_string ? $_bwk_timezone_string : 'UTC' );
+}
+
+function current_time( $type ) {
+    $timestamp = time();
+
+    if ( 'timestamp' === $type ) {
+        return $timestamp;
+    }
+
+    if ( 'mysql' === $type ) {
+        return gmdate( 'Y-m-d H:i:s', $timestamp );
+    }
+
+    return $timestamp;
+}
+
+function wp_date( $format, $timestamp, $timezone = null ) {
+    if ( ! $timezone instanceof DateTimeZone ) {
+        $timezone = wp_timezone();
+    }
+
+    $datetime = new DateTimeImmutable( '@' . (int) $timestamp );
+    $datetime = $datetime->setTimezone( $timezone );
+
+    return $datetime->format( $format );
+}
+
+function get_gmt_from_date( $date_string, $format = 'Y-m-d H:i:s' ) {
+    try {
+        $timezone = wp_timezone();
+        $datetime = new DateTimeImmutable( $date_string, $timezone );
+        return $datetime->setTimezone( new DateTimeZone( 'UTC' ) )->format( $format );
+    } catch ( Exception $exception ) {
+        return $date_string;
+    }
+}


### PR DESCRIPTION
## Summary
- convert profit summary range bounds to GMT while keeping the local metadata untouched
- bucket profit series data using the same GMT-normalized bounds so UTC ledger rows land on the correct local day
- add regression coverage for non-UTC WooCommerce stores plus a manual test script for restricted environments

## Testing
- php tests/manual-ledger-check.php
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cf577e963883308b6d87d2a99ace8f