### PR TITLE
Add WooCommerce product picker integration for line items

### DIFF
--- a/bwk-accounting-lite/admin/views-invoice-edit.php
+++ b/bwk-accounting-lite/admin/views-invoice-edit.php
@@ -39,6 +39,7 @@ $number_value = $invoice ? $invoice->number : $next_invoice_number;
                         $picker_classes   = 'bwk-product-picker';
                         $option_label     = $it->item_name;
                         $product_selected = ! empty( $product_id );
+                        $search_value     = '';
 
                         if ( $product_selected ) {
                             $picker_classes .= ' is-active';
@@ -46,6 +47,10 @@ $number_value = $invoice ? $invoice->number : $next_invoice_number;
 
                         if ( $product_sku ) {
                             $option_label .= ' (' . $product_sku . ')';
+                        }
+
+                        if ( $product_selected ) {
+                            $search_value = $option_label;
                         }
                         ?>
                         <tr class="bwk-item-row">
@@ -59,7 +64,7 @@ $number_value = $invoice ? $invoice->number : $next_invoice_number;
                                         <?php esc_html_e( 'Use existing product', 'bwk-accounting-lite' ); ?>
                                     </label>
                                     <div class="<?php echo esc_attr( $picker_classes ); ?>">
-                                        <input type="search" class="bwk-product-search" placeholder="<?php esc_attr_e( 'Search for a product…', 'bwk-accounting-lite' ); ?>" />
+                                        <input type="search" class="bwk-product-search" value="<?php echo esc_attr( $search_value ); ?>" placeholder="<?php esc_attr_e( 'Search for a product…', 'bwk-accounting-lite' ); ?>" autocomplete="off" />
                                         <select class="bwk-product-select">
                                             <option value=""><?php esc_html_e( 'Select a product', 'bwk-accounting-lite' ); ?></option>
                                             <?php if ( $product_selected ) : ?>

--- a/bwk-accounting-lite/admin/views-quote-edit.php
+++ b/bwk-accounting-lite/admin/views-quote-edit.php
@@ -38,6 +38,7 @@ $quote_id = $quote ? intval( $quote->id ) : 0;
                         $picker_classes   = 'bwk-product-picker';
                         $option_label     = $it->item_name;
                         $product_selected = ! empty( $product_id );
+                        $search_value     = '';
 
                         if ( $product_selected ) {
                             $picker_classes .= ' is-active';
@@ -45,6 +46,10 @@ $quote_id = $quote ? intval( $quote->id ) : 0;
 
                         if ( $product_sku ) {
                             $option_label .= ' (' . $product_sku . ')';
+                        }
+
+                        if ( $product_selected ) {
+                            $search_value = $option_label;
                         }
                         ?>
                         <tr class="bwk-item-row">
@@ -58,7 +63,7 @@ $quote_id = $quote ? intval( $quote->id ) : 0;
                                         <?php esc_html_e( 'Use existing product', 'bwk-accounting-lite' ); ?>
                                     </label>
                                     <div class="<?php echo esc_attr( $picker_classes ); ?>">
-                                        <input type="search" class="bwk-product-search" placeholder="<?php esc_attr_e( 'Search for a product…', 'bwk-accounting-lite' ); ?>" />
+                                        <input type="search" class="bwk-product-search" value="<?php echo esc_attr( $search_value ); ?>" placeholder="<?php esc_attr_e( 'Search for a product…', 'bwk-accounting-lite' ); ?>" autocomplete="off" />
                                         <select class="bwk-product-select">
                                             <option value=""><?php esc_html_e( 'Select a product', 'bwk-accounting-lite' ); ?></option>
                                             <?php if ( $product_selected ) : ?>

--- a/bwk-accounting-lite/includes/class-admin-menu.php
+++ b/bwk-accounting-lite/includes/class-admin-menu.php
@@ -33,12 +33,16 @@ class BWK_Admin_Menu {
         }
         wp_enqueue_style( 'bwk-admin', BWK_AL_URL . 'admin/css/admin.css', array(), BWK_AL_VERSION );
         wp_enqueue_script( 'bwk-admin', BWK_AL_URL . 'admin/js/admin.js', array( 'jquery' ), BWK_AL_VERSION, true );
+        $rest_url   = function_exists( 'rest_url' ) ? rest_url( 'bwk-accounting/v1/products' ) : '';
+        $rest_nonce = $rest_url ? wp_create_nonce( 'wp_rest' ) : '';
         wp_localize_script(
             'bwk-admin',
             'bwkAdminData',
             array(
                 'ajaxUrl'          => admin_url( 'admin-ajax.php' ),
                 'searchNonce'      => wp_create_nonce( 'bwk_search_products' ),
+                'restUrl'          => $rest_url,
+                'restNonce'        => $rest_nonce,
                 'productsEnabled'  => class_exists( 'WooCommerce' ),
                 'i18n'             => array(
                     'useProductLabel'   => __( 'Use existing product', 'bwk-accounting-lite' ),


### PR DESCRIPTION
## Summary
- enhance invoice and quote rows to keep the WooCommerce selector visible alongside custom item descriptions
- extend the admin javascript to drive the picker via REST or AJAX, hydrate line items from the selected product, and reset fields when toggled off
- expose a reusable product lookup helper, localize REST credentials, and register a secured REST endpoint for product searches

## Testing
- php -l admin/views-invoice-edit.php
- php -l admin/views-quote-edit.php
- php -l includes/class-admin-menu.php
- php -l includes/class-admin-products.php
- php -l includes/class-rest.php
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6a15989c8330b2c75f85c4a03c46