### PR TITLE
Ensure invoice and quote print views render on front end

### DIFF
--- a/bwk-accounting-lite/includes/class-invoices-tables.php
+++ b/bwk-accounting-lite/includes/class-invoices-tables.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BWK_Invoices {
     public static function init() {
         add_action( 'admin_post_bwk_save_invoice', array( __CLASS__, 'save_invoice' ) );
-        add_action( 'admin_init', array( __CLASS__, 'maybe_render_print_invoice' ) );
+        add_action( 'template_redirect', array( __CLASS__, 'maybe_render_print_invoice' ) );
         add_shortcode( 'bwk_invoice', array( __CLASS__, 'shortcode_invoice' ) );
     }
 
@@ -135,6 +135,10 @@ class BWK_Invoices {
     }
 
     public static function maybe_render_print_invoice() {
+        if ( is_admin() ) {
+            return;
+        }
+
         if ( isset( $_GET['bwk_invoice'] ) ) {
             $id    = intval( $_GET['bwk_invoice'] );
             $nonce = isset( $_GET['_nonce'] ) ? sanitize_text_field( $_GET['_nonce'] ) : '';

--- a/bwk-accounting-lite/includes/class-quotes-table.php
+++ b/bwk-accounting-lite/includes/class-quotes-table.php
@@ -13,7 +13,7 @@ class BWK_Quotes_Table {
     public static function init() {
         add_action( 'admin_post_bwk_save_quote', array( __CLASS__, 'save_quote' ) );
         add_action( 'admin_post_bwk_convert_quote', array( __CLASS__, 'convert_to_invoice' ) );
-        add_action( 'admin_init', array( __CLASS__, 'maybe_render_print_quote' ) );
+        add_action( 'template_redirect', array( __CLASS__, 'maybe_render_print_quote' ) );
         add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
     }
 
@@ -209,6 +209,10 @@ class BWK_Quotes_Table {
     }
 
     public static function maybe_render_print_quote() {
+        if ( is_admin() ) {
+            return;
+        }
+
         if ( isset( $_GET['bwk_quote'] ) ) {
             $id    = intval( $_GET['bwk_quote'] );
             $nonce = isset( $_GET['_nonce'] ) ? sanitize_text_field( $_GET['_nonce'] ) : '';


### PR DESCRIPTION
## Summary
- switch the invoice and quote print handlers to run during `template_redirect` so they fire on the front end
- add guards to skip the print handlers during admin requests to avoid hijacking back-end loads

## Testing
- not run (WordPress runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf7d73d9148330bdc5049999cd9341